### PR TITLE
Fix for JAR differentiation; bug 639615

### DIFF
--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -27,7 +27,7 @@ def test_xpcnativewrappers():
 
 def test_ignore_macstuff():
     "Tests that the content manager will ignore Mac-generated files"
-    
+
     err = ErrorBundle()
     result = content.test_packed_packages(err,
                                           {"__MACOSX": None,
@@ -39,24 +39,25 @@ def test_ignore_macstuff():
     assert result == 0
 
 def test_jar_subpackage():
-    "Tests JAR files that are subpackages."
-    
-    err = ErrorBundle(None, True)
+    "Tests that JAR files are considered subpackages."
+
+    err = ErrorBundle()
+    err.set_type(PACKAGE_EXTENSION)
     mock_package = MockXPIManager(
         {"chrome/subpackage.jar":
              "tests/resources/content/subpackage.jar",
-         "nonsubpackage.jar":
+         "subpackage.jar":
              "tests/resources/content/subpackage.jar"})
-                        
+
     content.testendpoint_validator = \
         MockTestEndpoint(("test_inner_package", ))
-    
+
     result = content.test_packed_packages(
                                     err,
                                     {"chrome/subpackage.jar":
                                       {"extension": "jar",
                                        "name_lower": "subpackage.jar"},
-                                     "nonsubpackage.jar":
+                                     "subpackage.jar":
                                       {"extension": "jar",
                                        "name_lower": "subpackage.jar"},
                                        },
@@ -68,9 +69,37 @@ def test_jar_subpackage():
                                     2)
     content.testendpoint_validator.assert_expectation(
                                     "test_inner_package",
-                                    1,
+                                    2,
                                     "subpackage")
-    
+
+def test_xpi_subpackage():
+    "XPIs should never be subpackages; only nested extensions"
+
+    err = ErrorBundle()
+    err.set_type(PACKAGE_EXTENSION)
+    mock_package = MockXPIManager(
+        {"chrome/package.xpi":
+             "tests/resources/content/subpackage.jar"})
+
+    content.testendpoint_validator = \
+        MockTestEndpoint(("test_package", ))
+
+    result = content.test_packed_packages(
+        err,
+        {"chrome/package.xpi": {"extension": "xpi",
+                                "name_lower": "package.xpi"}},
+        mock_package)
+
+    print result
+    assert result == 1
+    content.testendpoint_validator.assert_expectation(
+        "test_package",
+        1)
+    content.testendpoint_validator.assert_expectation(
+        "test_package",
+        0,
+        "subpackage")
+
 
 def test_xpi_tiererror():
     "Tests that tiers are reset when a subpackage is encountered"
@@ -92,44 +121,51 @@ def test_xpi_tiererror():
     assert err.tier == 2
     assert all(x == 1 for x in content.testendpoint_validator.found_tiers)
 
-def test_xpi_nonsubpackage():
+def test_jar_nonsubpackage():
     "Tests XPI files that are not subpackages."
-    
-    err = ErrorBundle(None, True)
+
+    err = ErrorBundle()
+    err.set_type(PACKAGE_MULTI)
+    err.save_resource("is_multipackage", True)
     mock_package = MockXPIManager(
-        {"foo.xpi":
+        {"foo.jar":
+             "tests/resources/content/subpackage.jar",
+         "chrome/bar.jar":
              "tests/resources/content/subpackage.jar"})
-                        
-    content.testendpoint_validator = MockTestEndpoint(("test_package", ))
-    
+
+    content.testendpoint_validator = MockTestEndpoint(("test_inner_package", ))
+
     result = content.test_packed_packages(
                                     err,
-                                    {"foo.xpi":
-                                      {"extension": "xpi",
-                                       "name_lower": "foo.xpi"}},
+                                    {"foo.jar":
+                                      {"extension": "jar",
+                                       "name_lower": "foo.jar"},
+                                     "chrome/bar.jar":
+                                      {"extension": "jar",
+                                       "name_lower": "bar.jar"}},
                                     mock_package)
     print result
-    assert result == 1
+    assert result == 2
     content.testendpoint_validator.assert_expectation(
-                                    "test_package",
-                                    1)
+                                    "test_inner_package",
+                                    2)
     content.testendpoint_validator.assert_expectation(
-                                    "test_package",
+                                    "test_inner_package",
                                     0,
                                     "subpackage")
-    
+
 
 def test_markup():
     "Tests markup files in the content validator."
-    
+
     err = ErrorBundle(None, True)
     mock_package = MockXPIManager(
         {"foo.xml":
              "tests/resources/content/junk.xpi"})
-                        
+
     content.testendpoint_markup = \
         MockMarkupEndpoint(("process", ))
-    
+
     result = content.test_packed_packages(
                                     err,
                                     {"foo.xml":
@@ -145,18 +181,18 @@ def test_markup():
                                     "process",
                                     0,
                                     "subpackage")
-    
+
 def test_css():
     "Tests css files in the content validator."
-    
+
     err = ErrorBundle(None, True)
     mock_package = MockXPIManager(
         {"foo.css":
              "tests/resources/content/junk.xpi"})
-                        
+
     content.testendpoint_css = \
         MockTestEndpoint(("test_css_file", ))
-    
+
     result = content.test_packed_packages(
                                     err,
                                     {"foo.css":
@@ -172,20 +208,20 @@ def test_css():
                                     "test_css_file",
                                     0,
                                     "subpackage")
-    
+
 
 def test_langpack():
     "Tests a language pack in the content validator."
-    
+
     err = ErrorBundle(None, True)
     err.set_type(PACKAGE_LANGPACK)
     mock_package = MockXPIManager(
         {"foo.dtd":
              "tests/resources/content/junk.xpi"})
-                        
+
     content.testendpoint_langpack = \
         MockTestEndpoint(("test_unsafe_html", ))
-    
+
     result = content.test_packed_packages(
                                     err,
                                     {"foo.dtd":
@@ -201,18 +237,18 @@ def test_langpack():
                                     "test_unsafe_html",
                                     0,
                                     "subpackage")
-    
+
 
 def test_jar_subpackage_bad():
     "Tests JAR files that are bad subpackages."
-    
+
     err = ErrorBundle(None, True)
     mock_package = MockXPIManager({"chrome/subpackage.jar":
                             "tests/resources/content/junk.xpi"})
-                        
+
     content.testendpoint_validator = \
         MockTestEndpoint(("test_inner_package", ))
-    
+
     result = content.test_packed_packages(
                                     err,
                                     {"chrome/subpackage.jar":
@@ -222,21 +258,21 @@ def test_jar_subpackage_bad():
                                     mock_package)
     print result
     assert err.failed()
-    
+
 class MockTestEndpoint(object):
     """Simulates a test module and reports whether individual tests
     have been attempted on it."""
-    
+
     def __init__(self, expected, td_error=False):
         expectations = {}
         for expectation in expected:
             expectations[expectation] = {"count": 0,
                                          "subpackage": 0}
-        
+
         self.expectations = expectations
         self.td_error = td_error
         self.found_tiers = []
-        
+
     def _tier_test(self, err, package_contents, xpi):
         "A simulated test case for tier errors"
         print "Generating subpackage tier error..."
@@ -246,11 +282,11 @@ class MockTestEndpoint(object):
                   "Just a test")
 
     def __getattribute__(self, name):
-        """"Detects requests for validation tests and returns an
+        """Detects requests for validation tests and returns an
         object that simulates the outcome of a test."""
-        
+
         print "Requested: %s" % name
-        
+
         if name == "test_package" and self.td_error:
             return self._tier_test
 
@@ -260,10 +296,10 @@ class MockTestEndpoint(object):
                     "_tier_test",
                     "found_tiers"):
             return object.__getattribute__(self, name)
-        
+
         if name in self.expectations:
             self.expectations[name]["count"] += 1
-        
+
         if name == "test_package":
             def wrap(package, name, expectation=PACKAGE_ANY):
                 pass
@@ -271,52 +307,52 @@ class MockTestEndpoint(object):
             def wrap(err, con, pak):
                 if isinstance(pak, xpi.XPIManager) and pak.subpackage:
                     self.expectations[name]["subpackage"] += 1
-        
+
         return wrap
-        
+
     def assert_expectation(self, name, count, type_="count"):
         """Asserts that a particular test has been run a certain number
         of times"""
-        
+
         print self.expectations
         assert name in self.expectations
         print self.expectations[name][type_]
         assert self.expectations[name][type_] == count
-        
+
 
 class MockMarkupEndpoint(MockTestEndpoint):
     "Simulates the markup test module"
-    
+
     def __getattribute__(self, name):
-        
+
         if name == "MarkupParser":
             return lambda x: self
-        
+
         return MockTestEndpoint.__getattribute__(self, name)
-        
+
 
 class MockXPIManager(object):
     """Simulates an XPIManager object to make it much easier to test
     packages and their contents"""
-    
+
     def __init__(self, package_contents):
         self.contents = package_contents
-    
+
     def test(self):
         "Simulate an integrity check. Just return true."
         return True
-    
+
     def read(self, filename):
         "Simulates an unpack-to-memory operation."
-        
+
         prelim_resource = self.contents[filename]
-        
+
         if isinstance(prelim_resource, str):
-            
+
             resource = open(prelim_resource)
             data = resource.read()
             resource.close()
-        
+
             return data
-        
-    
+
+

--- a/validator/testcases/content.py
+++ b/validator/testcases/content.py
@@ -39,20 +39,20 @@ def test_xpcnativewrappers(err, package_contents=None, xpi_package=None):
 @decorator.register_test(tier=2)
 def test_packed_packages(err, package_contents=None, xpi_package=None):
     "Tests XPI and JAR files for naughty content."
-    
+
     processed_files = 0
 
     hash_whitelist = [x[:-1] for x in
                       open(os.path.join(os.path.dirname(__file__),
                                         'whitelist_hashes.txt')).readlines()]
-    
+
     # Iterate each item in the package.
     for name, data in package_contents.items():
-        
+
         if name.startswith("__MACOSX") or \
            name.startswith(".DS_Store"):
             continue
-        
+
         if name.split("/")[-1].startswith("._"):
             err.notice(("testcases_content",
                         "test_packed_packages",
@@ -62,7 +62,7 @@ def test_packed_packages(err, package_contents=None, xpi_package=None):
                         "with proper operation of the add-on down the road.",
                         "It is recommended that you delete the file"],
                        name)
-        
+
         try:
             file_data = xpi_package.read(name)
         except KeyError: # pragma: no cover
@@ -77,13 +77,9 @@ def test_packed_packages(err, package_contents=None, xpi_package=None):
         # If that item is a container file, unzip it and scan it.
         if data["extension"] == "jar":
             # This is either a subpackage or a nested theme.
-            
-            # Whether this is a subpackage or a nested theme is
-            # determined by whether it is in the root folder or not.
-            # Subpackages are always found in a directory such as
-            # /chrome or /content.
-            is_subpackage = name.count("/") > 0
-            
+
+            is_subpackage = not err.get_resource("is_multipackage")
+
             # Unpack the package and load it up.
             package = StringIO(file_data)
             sub_xpi = XPIManager(package, name, is_subpackage)
@@ -96,12 +92,14 @@ def test_packed_packages(err, package_contents=None, xpi_package=None):
                           "with corruption. Ensure that the file is valid.",
                           name)
                 continue
-            
+
             temp_contents = sub_xpi.get_file_data()
-            
+
             # Let the error bunder know we're in a sub-package.
             err.push_state(data["name_lower"])
-            err.set_type(PACKAGE_SUBPACKAGE) # Subpackage
+            err.set_type(PACKAGE_SUBPACKAGE if
+                         is_subpackage else
+                         PACKAGE_THEME)
             err.set_tier(1)
             testendpoint_validator.test_inner_package(err,
                                                       temp_contents,
@@ -109,44 +107,44 @@ def test_packed_packages(err, package_contents=None, xpi_package=None):
             package.close()
             err.pop_state()
             err.set_tier(2)
-            
+
         elif data["extension"] == "xpi":
             # It's not a subpackage, it's a nested extension. These are
             # found in multi-extension packages.
-            
+
             # Unpack!
             package = StringIO(file_data)
-            
+
             err.push_state(data["name_lower"])
             err.set_tier(1)
 
             # There are no expected types for packages within a multi-
             # item package.
             testendpoint_validator.test_package(err, package, name)
-            
+
             package.close()
             err.pop_state()
             err.set_tier(2) # Reset to the current tier
-            
+
         elif data["extension"] in ("xul", "xml", "html", "xhtml"):
-            
+
             parser = testendpoint_markup.MarkupParser(err)
             parser.process(name,
                            file_data,
                            data["extension"])
-            
+
             processed = True
-                
-            
+
+
         elif data["extension"] in ("css", "js", "jsm"):
-            
+
             if not file_data:
                 continue
-            
+
             # Skip BOMs and the like
             while not is_standard_ascii(file_data[0]):
                 file_data = file_data[1:]
-            
+
             if data["extension"] == "css":
                 testendpoint_css.test_css_file(err,
                                                name,
@@ -157,13 +155,13 @@ def test_packed_packages(err, package_contents=None, xpi_package=None):
                                              file_data)
         # This is tested in test_langpack.py
         if err.detected_type == PACKAGE_LANGPACK and not processed:
-            
+
             testendpoint_langpack.test_unsafe_html(err,
                                                    name,
                                                    file_data)
-        
+
         # This aids in creating unit tests.
         processed_files += 1
-            
+
     return processed_files
-    
+

--- a/validator/typedetection.py
+++ b/validator/typedetection.py
@@ -39,6 +39,7 @@ def detect_type(err, install_rdf=None, xpi_package=None):
     
     if type_ is not None:
         if type_ in translated_types:
+            err.save_resource("is_multipackage", True, pushable=True)
             # Make sure we translate back to the normalized version
             return translated_types[type_]
         else:


### PR DESCRIPTION
This changes the way subpackages and nested themes are differentiated. The new method is the documented way (per MDN) to be doing things.

Also, forgive the trailing whitespace issues; the other pull request has a commit that fixes this, which I can rebase in later.
