### PR TITLE
Bug 648416 - Updated hidden files to throw a warning

### DIFF
--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -25,19 +25,6 @@ def test_xpcnativewrappers():
     content.test_xpcnativewrappers(err, {}, None)
     assert err.failed()
 
-def test_ignore_macstuff():
-    "Tests that the content manager will ignore Mac-generated files"
-
-    err = ErrorBundle()
-    result = content.test_packed_packages(err,
-                                          {"__MACOSX": None,
-                                           "__MACOSX/foo": None,
-                                           "__MACOSX/bar": None,
-                                           "__MACOSX/.DS_Store": None,
-                                           ".DS_Store": None},
-                                          None)
-    assert result == 0
-
 def test_jar_subpackage():
     "Tests JAR files that are subpackages."
 
@@ -189,9 +176,9 @@ def test_hidden_files():
     assert err.failed()
 
     err = ErrorBundle()
-    mock_package_mac = MockXPIManager({"__MACOSX/foo":
+    mock_package_mac = MockXPIManager({"dir/__MACOSX/foo":
                                           "tests/resources/content/junk.xpi"})
-    content.test_packed_packages(err, {"__MACOSX/foo":
+    content.test_packed_packages(err, {"dir/__MACOSX/foo":
                                            {"extension": "foo",
                                             "name_lower": "foo"}},
                                  mock_package_mac)

--- a/validator/testcases/content.py
+++ b/validator/testcases/content.py
@@ -1,4 +1,5 @@
 import hashlib
+import re
 from StringIO import StringIO
 
 from validator import decorator
@@ -46,11 +47,14 @@ def test_packed_packages(err, package_contents=None, xpi_package=None):
                       open(os.path.join(os.path.dirname(__file__),
                                         'whitelist_hashes.txt')).readlines()]
 
+    macosx_regex = re.compile("__MACOSX")
+
     # Iterate each item in the package.
     for name, data in package_contents.items():
 
-        if name.startswith("__MACOSX") or \
-           name.startswith("."):
+        if (macosx_regex.search(name) or
+            name.startswith(".") or
+            name.split("/")[-1].startswith(".")):
             err.warning(
                 err_id=("testcases_content", "test_packed_packages",
                         "hidden_files"),
@@ -62,16 +66,6 @@ def test_packed_packages(err, package_contents=None, xpi_package=None):
                             "aren't included.",
                 filename=name)
             continue
-
-        if name.split("/")[-1].startswith("._"):
-            err.notice(("testcases_content",
-                        "test_packed_packages",
-                        "macintosh_junk"),
-                       "Garbage file found.",
-                       ["A junk file has been detected. It may cause problems "
-                        "with proper operation of the add-on down the road.",
-                        "It is recommended that you delete the file"],
-                       name)
 
         try:
             file_data = xpi_package.read(name)


### PR DESCRIPTION
Files that start with a dot or are in the __MACOSX folder now throw a warning. Also, old tests for Mac junk are removed as this takes a higher precedence.
