### PR TITLE
Added metadata for binary file types; bug 650100

### DIFF
--- a/tests/test_packagelayout.py
+++ b/tests/test_packagelayout.py
@@ -21,17 +21,20 @@ def test_blacklisted_files():
     """Tests that the validator will throw warnings on extensions
     containing files that have extensions which are not considered
     safe."""
-    
-    _do_test("tests/resources/packagelayout/ext_blacklist.xpi",
-             packagelayout.test_blacklisted_files,
-             True)
+
+    err = _do_test("tests/resources/packagelayout/ext_blacklist.xpi",
+                   packagelayout.test_blacklisted_files,
+                   True)
+    assert err.metadata["contains_binary_extension"]
 
 def test_blacklisted_magic_numbers():
     "Tests that blacklisted magic numbers are banned"
 
-    _do_test("tests/resources/packagelayout/magic_number.xpi",
-            packagelayout.test_blacklisted_files,
-            True)
+    err = _do_test("tests/resources/packagelayout/magic_number.xpi",
+                   packagelayout.test_blacklisted_files,
+                   True)
+    assert err.metadata["contains_binary_content"]
+
 
 # These functions will test the code with manually constructed packages
 # that contain valid or failing versions of the specified package. The
@@ -40,7 +43,7 @@ def test_blacklisted_magic_numbers():
 
 def test_theme_passing():
     "Tests the layout of a proper theme"
-    
+
     _do_test("tests/resources/packagelayout/theme.jar",
              packagelayout.test_theme_layout,
              False)
@@ -48,7 +51,7 @@ def test_theme_passing():
 def test_extra_unimportant():
     """Tests the layout of a theme that contains an unimportant but
     extra directory."""
-    
+
     _do_test("tests/resources/packagelayout/theme_extra_unimportant.jar",
              packagelayout.test_theme_layout,
              False)
@@ -56,28 +59,28 @@ def test_extra_unimportant():
 def _do_simulated_test(function, structure, failure=False, ff4=False):
     """"Performs a test on a function or set of functions without
     generating a full package."""
-    
+
     dict_structure = {"__MACOSX/foo.bar": True}
     for item in structure:
         dict_structure[item] = True
-    
+
     err = ErrorBundle(None, True)
     err.save_resource("ff4", ff4)
     function(err, dict_structure, None)
-    
+
     err.print_summary(True)
-    
+
     if failure:
         assert err.failed()
     else:
         assert not err.failed()
-    
+
     return err
 
 def test_langpack_max():
     """Tests the package layout module out on a simulated language pack
     containing the largest number of possible elements."""
-    
+
     _do_simulated_test(packagelayout.test_langpack_layout,
                        ["install.rdf",
                         "chrome/foo.jar",
@@ -94,7 +97,7 @@ def test_langpack_max():
 def test_dict_max():
     """Tests the package layout module out on a simulated dictionary
     containing the largest number of possible elements."""
-    
+
     _do_simulated_test(packagelayout.test_dictionary_layout,
                        ["install.rdf",
                         "dictionaries/foo.aff",
@@ -107,10 +110,10 @@ def test_dict_max():
 
 def test_unknown_file():
     """Tests that the unknown file detection function is working."""
-    
+
     # We test against langpack because it is incredibly strict in its
     # file format.
-    
+
     _do_simulated_test(packagelayout.test_langpack_layout,
                        ["install.rdf",
                         "chrome/foo.jar",
@@ -119,43 +122,43 @@ def test_unknown_file():
 
 def test_disallowed_file():
     """Tests that outright improper files are blocked."""
-    
+
     # We test against langpack because it is incredibly strict in its
     # file format.
-    
+
     _do_simulated_test(packagelayout.test_langpack_layout,
                        ["install.rdf",
                         "chrome/foo.jar",
                         "chrome.manifest",
                         "foo.bar"],
                        True)
-    
+
 
 def test_extra_obsolete():
     """Tests that unnecessary, obsolete files are detected."""
-    
+
     err = ErrorBundle(None, True)
-    
+
     # Tests that chromelist.txt is treated (with and without slashes in
     # the path) as an obsolete file.
     assert not packagelayout.test_unknown_file(err, "x//whatever.txt")
     assert not packagelayout.test_unknown_file(err, "whatever.txt")
     assert packagelayout.test_unknown_file(err, "x//chromelist.txt")
     assert packagelayout.test_unknown_file(err, "chromelist.txt")
-    
+
     assert not err.failed()
-    
+
 
 def test_has_installrdfs():
     """Tests that install.rdf files are present and that subpackage
     rules are respected."""
-    
+
     # Test package to make sure has_install_rdf is set to True.
     assert not _do_installrdfs(packagelayout.test_layout_all)
     assert _do_installrdfs(packagelayout.test_layout_all, False)
-    
+
     mock_xpi_subpack = MockXPIAll(True)
-    
+
     # Makes sure the above test is ignored if the package is a
     # subpackage.
     assert not _do_installrdfs(packagelayout.test_layout_all,
@@ -164,31 +167,31 @@ def test_has_installrdfs():
     assert not _do_installrdfs(packagelayout.test_layout_all,
                                True,
                                mock_xpi_subpack)
-    
+
 
 
 class MockXPIAll:
     "Simulates an XPI package manager object"
-    
+
     def __init__(self, subpackage=False):
         self.subpackage = subpackage
-        
+
 
 def _do_installrdfs(function, has_install_rdf=True, xpi=None):
     "Helps to test that install.rdf files are present"
-    
+
     err = ErrorBundle(None, True)
-    
+
     if xpi is None:
         xpi = MockXPIAll()
-    
+
     if has_install_rdf:
         content = {"install.rdf" : True}
         err.save_resource("has_install_rdf", True)
     else:
         content = {}
     function(err, content, xpi)
-    
+
     return err.failed()
-    
+
 

--- a/validator/testcases/packagelayout.py
+++ b/validator/testcases/packagelayout.py
@@ -66,6 +66,8 @@ def test_blacklisted_files(err, package_contents=None, xpi_package=None):
         # Simple test to ensure that the extension isn't blacklisted
         extension = file_["extension"]
         if extension in blacklisted_extensions:
+            # Note that there is a binary extension in the metadata
+            err.metadata["contains_binary_extension"] = True
             err.warning(("testcases_packagelayout",
                          "test_blacklisted_files",
                          "disallowed_extension"),
@@ -81,6 +83,8 @@ def test_blacklisted_files(err, package_contents=None, xpi_package=None):
         zip = xpi_package.zf.open(name)
         bytes = tuple([ord(x) for x in zip.read(4)])  # Longest is 4 bytes
         if [x for x in blacklisted_magic_numbers if bytes[0:len(x)] == x]:
+            # Note that there is binary content in the metadata
+            err.metadata["contains_binary_content"] = True
             err.warning(("testcases_packagelayout",
                          "test_blacklisted_files",
                          "disallowed_file_type"),


### PR DESCRIPTION
Adds metadata elements when binary extensions and content are present in the add-on.

```
metadata["contains_binary_extension"] # Found via file extensions
metadata["contains_binary_content"] # Found via magic numbers
```
