### PR TITLE
Bug 650380 - Allow for version-dependent tests

### DIFF
--- a/tests/test_submain.py
+++ b/tests/test_submain.py
@@ -7,14 +7,14 @@ from validator.constants import *
 
 def test_prepare_package():
     "Tests that the prepare_package function passes for valid data"
-    
+
     tp = submain.test_package
     submain.test_package = lambda w,x,y,z: True
-    
+
     err = ErrorBundle(None, True)
     assert submain.prepare_package(err, "tests/resources/main/foo.xpi") == True
     submain.test_package = tp
-   
+
 def test_prepare_package_extension():
     "Tests that bad extensions get outright rejections"
 
@@ -27,34 +27,34 @@ def test_prepare_package_extension():
 
 def test_prepare_package_missing():
     "Tests that the prepare_package function fails when file is not found"
-    
+
     err = ErrorBundle(None, True)
     submain.prepare_package(err, "foo/bar/asdf/qwerty.xyz")
-    
+
     assert err.failed()
-    
+
 def test_prepare_package_bad_file():
     "Tests that the prepare_package function fails for unknown files"
-    
+
     err = ErrorBundle(None, True)
     submain.prepare_package(err, "tests/resources/main/foo.bar")
-    
+
     assert err.failed()
-    
+
 def test_prepare_package_xml():
     "Tests that the prepare_package function passes with search providers"
-    
+
     smts = submain.test_search
     submain.test_search = lambda err,y,z: True
-    
+
     err = ErrorBundle(None, True)
     submain.prepare_package(err, "tests/resources/main/foo.xml")
-    
+
     assert not err.failed()
-    
+
     submain.test_search = lambda err,y,z: err.error(("x"), "Failed")
     submain.prepare_package(err, "tests/resources/main/foo.xml")
-    
+
     assert err.failed()
     submain.test_search = smts
 
@@ -62,27 +62,27 @@ def test_prepare_package_xml():
 
 def test_test_inner_package():
     "Tests that the test_inner_package function works properly"
-    
+
     smd = submain.decorator
     decorator = MockDecorator()
     submain.decorator = decorator
     err = MockErrorHandler(decorator)
-    
+
     submain.test_inner_package(err, "foo", "bar")
-    
+
     assert not err.failed()
     submain.decorator = smd
-    
+
 def test_test_inner_package_failtier():
     "Tests that the test_inner_package function fails at a failed tier"
-    
+
     smd = submain.decorator
     decorator = MockDecorator(3)
     submain.decorator = decorator
     err = MockErrorHandler(decorator)
-    
+
     submain.test_inner_package(err, "foo", "bar")
-    
+
     assert err.failed()
     submain.decorator = smd
 
@@ -111,85 +111,88 @@ def test_populate_chrome_manifest():
 
 def test_test_inner_package_determined():
     "Tests that the determined test_inner_package function works properly"
-    
+
     smd = submain.decorator
     decorator = MockDecorator(None, True)
     submain.decorator = decorator
     err = MockErrorHandler(decorator, True)
-    
+
     submain.test_inner_package(err, "foo", "bar")
-    
+
     assert not err.failed()
     assert decorator.last_tier == 5
     submain.decorator = smd
-    
+
 def test_test_inner_package_failtier():
     "Tests the test_inner_package function in determined mode while failing"
-    
+
     smd = submain.decorator
     decorator = MockDecorator(3, True)
     submain.decorator = decorator
     err = MockErrorHandler(decorator, True)
-    
+
     submain.test_inner_package(err, "foo", "bar")
-    
+
     assert err.failed()
     assert decorator.last_tier == 5
     submain.decorator = smd
-    
+
 class MockDecorator:
-    
+
     def __init__(self, fail_tier=None, determined=False):
         self.determined = determined
         self.ordering = [1]
         self.fail_tier = fail_tier
         self.last_tier = 0
-    
+
     def get_tiers(self):
         "Returns unordered tiers. These must be in a random order."
         return (4, 1, 3, 5, 2)
-    
+
     def get_tests(self, tier, type):
         "Should return a list of tests that occur in a certain order"
-        
+
         self.on_tier = tier
-        
+
         print "Retrieving Tests: Tier %d" % tier
-        
+
         if self.fail_tier is not None:
             if tier == self.fail_tier:
                 print "> Fail Tier"
-                
-                yield {"test":lambda x,y,z: x.fail_tier(),
-                       "simple":False}
-            
+
+                yield {"test": lambda x,y,z: x.fail_tier(),
+                       "simple": False,
+                       "versions" :None}
+
             assert tier <= self.fail_tier or self.determined
-            
-        
+
+
         self.last_tier = tier
-        
+
         for x in range(1,10): # Ten times because we care
             print "Yielding Complex"
-            yield {"test":lambda x,y,z: x.report(tier),
-                   "simple":False}
+            yield {"test": lambda x,y,z: x.report(tier),
+                   "simple": False,
+                   "versions": None}
             print "Yielding Simple"
-            yield {"test":lambda x,y=None,z=None: x.test_simple(y, z),
-                   "simple":True}
-        
+            yield {"test": lambda x,y=None,z=None: x.test_simple(y, z),
+                   "simple": True,
+                   "versions": None}
+
     def report_tier(self, tier):
         "Checks to make sure the last test run is on the current tier."
-        
+
         assert tier == self.on_tier
-        
+
     def report_fail(self):
         "Alerts the tester to a failure"
-        
+
         print self.on_tier
         print self.fail_tier
         assert self.on_tier == self.fail_tier
-        
+
 class MockErrorHandler:
-    
+
     def __init__(self, mock_decorator, determined=False):
         self.decorator = mock_decorator
         self.detected_type = 0
@@ -203,7 +206,7 @@ class MockErrorHandler:
         "Saves a resource to the bundler"
         resources = self.pushable_resources if pushable else self.resources
         resources[name] = value
-    
+
     def set_tier(self, tier):
         "Sets the tier"
         pass
@@ -211,18 +214,18 @@ class MockErrorHandler:
     def report(self, tier):
         "Passes the tier back to the mock decorator to verify the tier"
         self.decorator.report_tier(tier)
-        
+
     def fail_tier(self):
         "Simulates a failure"
         self.has_failed = True
         self.decorator.report_fail()
-        
+
     def test_simple(self, y, z):
         "Makes sure that the second two params of a simple test are respected"
-        
+
         assert y is None
         assert z is None
-        
+
     def failed(self, fail_on_warnings=False):
         "Simple accessor because the standard error handler has one"
         return self.has_failed
@@ -240,7 +243,7 @@ class MockXPIPackage:
     def test():
         "We don't ever want it to be faulty"
         return True
-    
+
     def get_file_data(self):
         "Returns the pre-populated file data"
         return self.file_data

--- a/tests/test_submain_versions.py
+++ b/tests/test_submain_versions.py
@@ -1,0 +1,73 @@
+import validator.submain
+from validator import decorator
+from validator.errorbundler import ErrorBundle
+
+def test_version_decorators_accepted():
+    """
+    Test that decorators that specify versions to target accept the proper
+    add-ons for testing.
+    """
+
+    err = ErrorBundle()
+    err.save_resource("supported_versions", {"firefox": ["1.2.3"]})
+
+    tests = decorator.TEST_TIERS
+    decorator.TEST_TIERS = {}
+
+    @decorator.register_test(tier=5, versions={"firefox": ["1.0.0",
+                                                           "1.2.3"]})
+    def version_test(err, package, xpi):
+        print "Ran test"
+        err.save_resource("executed", True)
+
+    print decorator.TEST_TIERS
+
+    validator.submain.test_inner_package(err, {}, None)
+
+    assert err.get_resource("executed")
+    decorator.TEST_TIERS = tests
+
+def test_version_decorators_denied_guid():
+    """
+    Test that decorators that specify versions to target deny add-ons that do
+    not support the particular app being tested.
+    """
+
+    err = ErrorBundle()
+    err.save_resource("supported_versions", {"firefox": ["1.2.3"]})
+
+    tests = decorator.TEST_TIERS
+    decorator.TEST_TIERS = {}
+
+    @decorator.register_test(tier=5, versions={"foobarfox": ["1.0.0",
+                                                             "1.2.3"]})
+    def version_test(err, package, xpi):
+        raise Exception("Should not have run!")
+
+    print decorator.TEST_TIERS
+
+    validator.submain.test_inner_package(err, {}, None)
+    decorator.TEST_TIERS = tests
+
+def test_version_decorators_denied_version():
+    """
+    Test that decorators that specify versions to target deny add-ons that do
+    not support the particular app version being tested for.
+    """
+
+    err = ErrorBundle()
+    err.save_resource("supported_versions", {"firefox": ["1.2.3"]})
+
+    tests = decorator.TEST_TIERS
+    decorator.TEST_TIERS = {}
+
+    @decorator.register_test(tier=5, versions={"firefox": ["1.0.0",
+                                                           "2.0.0"]})
+    def version_test(err, package, xpi):
+        raise Exception("Should not have run!")
+
+    print decorator.TEST_TIERS
+
+    validator.submain.test_inner_package(err, {}, None)
+    decorator.TEST_TIERS = tests
+

--- a/validator/decorator.py
+++ b/validator/decorator.py
@@ -2,7 +2,7 @@
 TEST_TIERS = {}
 
 
-def register_test(tier=1, expected_type=None, simple=False):
+def register_test(tier=1, expected_type=None, simple=False, versions=None):
     "Registers tests for the validation flow."
 
     def wrap(function):
@@ -15,7 +15,8 @@ def register_test(tier=1, expected_type=None, simple=False):
         # Add a test object to the test's tier
         TEST_TIERS[tier].append({"test": function,
                                  "type": expected_type,
-                                 "simple": simple})
+                                 "simple": simple,
+                                 "versions": versions})
 
         # Return the function to be run
         return function

--- a/validator/testcases/targetapplication.py
+++ b/validator/testcases/targetapplication.py
@@ -36,6 +36,7 @@ def test_targetedapplications(err, package_contents=None,
     ta_max_ver = install.uri("maxVersion")
 
     used_targets = []
+    all_supported_versions = {}
 
     # Isolate all of the bnodes referring to target applications
     for target_app in install.get_objects(None, ta_predicate):
@@ -122,6 +123,9 @@ def test_targetedapplications(err, package_contents=None,
                                 "install.rdf")
                     continue
 
+                all_supported_versions[found_guid] = \
+                    app_versions[min_ver_pos:max_ver_pos]
+
                 # Test whether it's a FF4 addon
 
                 # NOTE: This should probably also be extrapolated for
@@ -154,5 +158,6 @@ def test_targetedapplications(err, package_contents=None,
         if key in APPLICATIONS:
             supports.append(APPLICATIONS[key])
     err.save_resource("supports", supports)
+    err.save_resource("supported_versions", all_supported_versions)
 
 


### PR DESCRIPTION
A patch that allows specific versions to be supplied by the decorator.
