### PR TITLE
Fix for functional tests

### DIFF
--- a/validator/testcases/javascript/call_definitions.py
+++ b/validator/testcases/javascript/call_definitions.py
@@ -55,7 +55,8 @@ def xpcom_constructor(method, extend=False, mutate=False, pretraversed=False):
             if isinstance(parent.value, dict):
                 if extend and mutate:
                     if callable(parent.value["value"]):
-                        parent.value["value"] = copy.deepcopy(parent.value["value"]())
+                        parent.value["value"] = \
+                            copy.deepcopy(parent.value["value"](t=traverser))
 
                     parent.value["value"].update(inst.value["value"])
                     return parent


### PR DESCRIPTION
Made a stupid mistake and didn't realize that the XPCOM instance generator called value lambdas. This adds the traverser parameter, which is now mandatory. It also fixes the functional tests.
