### PR TITLE
Changed compatibility_binary testcase to tier 5 (bug 658565)

### DIFF
--- a/validator/testcases/packagelayout.py
+++ b/validator/testcases/packagelayout.py
@@ -107,7 +107,7 @@ def test_blacklisted_files(err, package_contents=None, xpi_package=None):
 
 
 @decorator.register_test(
-        tier=1,
+        tier=5,
         versions={"{ec8030f7-c20a-464f-9b0e-13a3a9e97384}":
                       versions_after("firefox", "4.2a1pre")})
 def test_compatibility_binary(err, package_contents, xpi_package):


### PR DESCRIPTION
Previously, maxVersion override information was being saved during the targetapplication testcase, which happen during tier 1. If an add-on that would not otherwise run the compatibility_binary testcase because of its version support encountered the test (which was previously also on tier 1 like the standard restricted_binary testcase) before the targetapplication testcase, it would not meet the requirements to run and the test would pass.
