### PR TITLE
Fix for issue regarding supported versions traceback on some add-ons.

### DIFF
--- a/tests/test_targetapplication.py
+++ b/tests/test_targetapplication.py
@@ -80,10 +80,12 @@ def test_dup_targets():
 def test_has_installrdfs():
     """Tests that install.rdf files are present."""
 
-    err = ErrorBundle(None, True)
+    err = ErrorBundle()
 
     # Test package to make sure has_install_rdf is set to True.
     assert targetapp.test_targetedapplications(err, None) is None
+    # The supported versions list must be empty or other tests will fail.
+    assert err.supported_versions == {}
 
 
 def test_is_ff4():

--- a/validator/testcases/targetapplication.py
+++ b/validator/testcases/targetapplication.py
@@ -14,6 +14,7 @@ def test_targetedapplications(err, xpi_package=None):
 
     install = err.get_resource("install_rdf")
     if not install:
+        err.supported_versions = {}
         return
 
     APPROVED_APPLICATIONS = validator.constants.APPROVED_APPLICATIONS


### PR DESCRIPTION
Add-ons that do not have an install.rdf file (bad bad bad) will generate a traceback because the version comparison code thinks that the targetApplication test case hasn't run (it has, but there was no install.rdf so it exited early).

This fixes that issue by requiring the targetApplication test to produce a valid supported_applications value, even if it's empty.
