### PR TITLE
Converted nsIDOMFile test from an XPCOM member test to an instance action

### DIFF
--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -232,6 +232,15 @@ def test_fx7_nsIDOMFile():
     assert len(err.notices) == 1
     assert err.compat_summary["errors"]
 
+    err = _do_real_test_raw("""
+    var x = document.getElementById("whatever");
+    x.getAsDataURL();
+    """, versions={'{ec8030f7-c20a-464f-9b0e-13a3a9e97384}':
+                       versions_after("firefox", "7.0a1")})
+    assert not err.failed()
+    assert len(err.notices) == 1
+    assert err.compat_summary["errors"]
+
 
 def test_fx7_nsIJSON():
     """Test that nsIJSON methods are flagged."""

--- a/validator/testcases/javascript/instanceactions.py
+++ b/validator/testcases/javascript/instanceactions.py
@@ -10,6 +10,7 @@ node
     the current node being evaluated
 """
 import types
+
 from jstypes import *
 
 
@@ -127,9 +128,17 @@ def setAttribute(args, traverser, node):
             context=traverser.context)
 
 
+def nsIDOMFile_deprec(args, traverser, node):
+    """A wrapper for call_definitions.nsIDOMFile_deprec."""
+    from call_definitions import nsIDOMFile_deprec as cd_nsIDOMFile_deprec
+    cd_nsIDOMFile_deprec(None, [], traverser)
+
+
 INSTANCE_DEFINITIONS = {"createElement": createElement,
                         "createElementNS": createElementNS,
                         "getInterface": getInterface,
                         "setAttribute": setAttribute,
-                        "QueryInterface": QueryInterface}
+                        "QueryInterface": QueryInterface,
+                        "getAsBinary": nsIDOMFile_deprec,
+                        "getAsDataURL": nsIDOMFile_deprec}
 

--- a/validator/testcases/javascript/predefinedentities.py
+++ b/validator/testcases/javascript/predefinedentities.py
@@ -52,12 +52,6 @@ INTERFACES = {
                         "Authors of bootstrapped add-ons must take care "
                         "to cleanup any component registrations "
                         "at shutdown"}}},
-    u"nsIDOMFile":
-        {"value":
-            {u"getAsDataURL":
-                {"return": call_definitions.nsIDOMFile_deprec},
-             u"getAsBinary":
-                {"return": call_definitions.nsIDOMFile_deprec}}},
     u"nsIJSON":
         {"value":
             {u"encode":
@@ -345,10 +339,6 @@ GLOBAL_ENTITIES = {
                                 {"xpcom_map":
                                      lambda:
                                         INTERFACES["nsIComponentRegistrar"]},
-                             u"nsIDOMFile":
-                                {"xpcom_map":
-                                     lambda:
-                                        INTERFACES["nsIDOMFile"]},
                              u"nsIJSON":
                                 {"xpcom_map":
                                      lambda:


### PR DESCRIPTION
Converted nsIDOMFile test from an XPCOM member test to an instance action test. (bug 670241)
