### PR TITLE
Add explanation messages to BANNED_IDENTIFIERS.

### DIFF
--- a/validator/testcases/javascript/actions.py
+++ b/validator/testcases/javascript/actions.py
@@ -85,10 +85,8 @@ def test_identifier(traverser, name):
         traverser.err.warning(("testcases_scripting",
                                "create_identifier",
                                "banned_identifier"),
-                              "Banned JavaScript Identifier",
-                              ["An identifier was used in the JavaScript that "
-                               "is not allowed due to security restrictions.",
-                               "Identifier: %s" % name],
+                              "Banned or deprecated JavaScript Identifier",
+                              predefinedentities.BANNED_IDENTIFIERS[name],
                               filename=traverser.filename,
                               line=traverser.line,
                               column=traverser.position,

--- a/validator/testcases/javascript/predefinedentities.py
+++ b/validator/testcases/javascript/predefinedentities.py
@@ -6,7 +6,14 @@ from call_definitions import xpcom_constructor as xpcom_const, python_wrap
 from jstypes import JSWrapper
 
 # A list of identifiers and member values that may not be used.
-BANNED_IDENTIFIERS = ("newThread", "processNextEvent")
+BANNED_IDENTIFIERS = {
+    u"newThread": "Creating threads from JavaScript is a common cause "
+                  "of crashes and is unsupported in recent versions of the platform",
+    u"processNextEvent": "Spinning the event loop with processNextEvent is a common "
+                         "cause of deadlocks, crashes, and other errors due to "
+                         "unintended reentrancy. Please use asynchronous callbacks "
+                         "instead wherever possible",
+}
 
 # For "dangerous" elements, specifying True will throw an error on all
 # detected instances of the particular object. Specifying a lambda function


### PR DESCRIPTION
We've had a few complaints about the lack of a useful message for the processNextEvent deprecation message. The original bug report specified that it should have a message. This commit rectifies that.
