### PR TITLE
Fixed JavaScript JAR path issues. Bug 703623

### DIFF
--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -89,8 +89,7 @@ def test_xpi_tiererror():
 
     err = ErrorBundle()
     mock_package = MockXPI(
-        {"foo.xpi":
-             "tests/resources/content/subpackage.jar"})
+        {"foo.xpi": "tests/resources/content/subpackage.jar"})
     content.testendpoint_validator = MockTestEndpoint(("test_package", ),
                                                       td_error=True)
 

--- a/tests/test_content_scripts.py
+++ b/tests/test_content_scripts.py
@@ -110,6 +110,9 @@ def test_packed_scripts_pollution():
     assert err.warnings
     assert not err.errors
 
+    eq_(err.warnings[0]["file"],
+        ['subpackage.jar', 'subsubpackage', 'foo/bar.js'])
+
 
 def test_packed_scripts_no_pollution():
     """
@@ -139,4 +142,5 @@ def test_packed_scripts_no_pollution():
     eq_(err.package_stack, [])
 
     assert not err.failed()
+
 

--- a/validator/testcases/content.py
+++ b/validator/testcases/content.py
@@ -223,7 +223,8 @@ def test_packed_scripts(err, xpi_package):
 
         # Set the error bundle's package state to what it was when we first
         # encountered the script file during the content tests.
-        err.package_stack = script_bundle["state"]
+        for archive in script_bundle["state"]:
+            err.push_state(archive)
 
         for script in script_bundle["scripts"]:
             file_data = unicodehelper.decode(package.read(script))
@@ -241,9 +242,8 @@ def test_packed_scripts(err, xpi_package):
                 testendpoint_js.test_js_file(err, script, file_data)
             run_regex_tests(file_data, err, script, is_js=True)
 
-    # We only run this testcase if the package stack is empty, return it to its
-    # original state.
-    err.package_stack = []
+        for i in range(len(script_bundle["state"])):
+            err.pop_state()
 
 
 def _process_file(err, xpi_package, name, file_data, name_lower,


### PR DESCRIPTION
Should fix bugs 703558 and 703623.

I didn't realize that the physical act of pushing and popping states determine file paths for error output.
