### PR TITLE
Bug 671387: Only flag data:/javascript: URLs in strings to reduce noise

### DIFF
--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -136,6 +136,12 @@ def test_incompatible_uris():
     assert not err.failed()
     assert not any(err.compat_summary.values())
 
+    err = _do_test_raw("""
+    var foo = { data: "LOL NOT THE CASE" };
+    """, versions=fx6)
+    assert not err.failed()
+    assert not any(err.compat_summary.values())
+
 def test_chrome_usage():
 
     err = _do_test_raw("""var foo = require("bar");""")

--- a/validator/testcases/regex.py
+++ b/validator/testcases/regex.py
@@ -207,7 +207,7 @@ def run_regex_tests(document, err, filename, context=None, is_js=False):
         if is_js:
             # javascript/data: URI usage in the address bar
             _compat_test(
-                    re.compile(r"\b(javascript|data):"),
+                    re.compile(r"['\"](javascript|data):"),
                     "javascript:/data: URIs may be incompatible with Firefox "
                     "6.",
                     ("Loading 'javascript:' and 'data:' URIs through the "


### PR DESCRIPTION
... Would that they could disappear entirely.
