### PR TITLE
Fixed resource consumption issue

### DIFF
--- a/validator/testcases/javascript/jstypes.py
+++ b/validator/testcases/javascript/jstypes.py
@@ -442,10 +442,12 @@ class JSArray(JSObject):
         if len(self.elements) > index:
             self.elements[index] = JSWrapper(value=value, traverser=traverser)
         else:
+            # Max out the array size at 100000
+            index = min(index, 100000)
             # Assigning to an index higher than the top of the list pads the
             # list with nulls
             while len(self.elements) < index:
-                self.elements.append(JSWrapper(traverser=traverser))
+                self.elements.append(None)
             self.elements.append(JSWrapper(value=value, traverser=traverser))
 
     def output(self):

--- a/validator/testcases/javascript/traverser.py
+++ b/validator/testcases/javascript/traverser.py
@@ -132,11 +132,8 @@ class Traverser:
             self.position = int(node["loc"]["start"]["column"])
 
         # Extract properties about the node that we're traversing
-        (branches,
-         establish_context,
-         action,
-         returns,
-         block_level) = DEFINITIONS[node["type"]]
+        (branches, establish_context, action, returns,
+             block_level) = DEFINITIONS[node["type"]]
 
         # If we're supposed to establish a context, do it now
         if establish_context:


### PR DESCRIPTION
Arbitrary array assignment at high indices creates too many null JSWrapper objects. The value has been capped at 100,000.

I can't think of an effective way to test for this. A test failure will crash the machine if the fix doesn't work. A test that the cap exists doesn't mean anything because the value is relatively arbitrary. A functional test would probably be most appropriate, but again, a failure would crash the machine.

I did test that there are no other `while` loops in the JS engine, so I don't think infinite loops will be an issue. There are no generators in the JS engine, so `for` loops won't be an issue with that either.
