### PR TITLE
Fixed subpackage version overwrite; bug 721423

### DIFF
--- a/tests/test_targetapplication.py
+++ b/tests/test_targetapplication.py
@@ -77,15 +77,46 @@ def test_dup_targets():
              True)
 
 
-def test_has_installrdfs():
-    """Tests that install.rdf files are present."""
+def test_missing_installrdfs_are_handled():
+    """
+    Tests that install.rdf files are present and supported_versions is set to
+    an empty dict if an install.rdf is not found.
+    """
 
     err = ErrorBundle()
+
+    # This is the default, but I'm specifying it for clarity of purpose.
+    err.supported_versions = None
 
     # Test package to make sure has_install_rdf is set to True.
     assert targetapp.test_targetedapplications(err, None) is None
     # The supported versions list must be empty or other tests will fail.
     assert err.supported_versions == {}
+
+
+def test_supported_versions_not_overwritten():
+    """
+    Test that supported_versions is not overwritten in subpackages (JARs) when
+    install.rdf files are tested for. This could otherwise happen because the
+    targetApplication tests previously gave an empty dict to supported_versions
+    in order to ensure a valid state when testing for version support.
+
+    If the supported_versions field in an error bundle is None, it represents
+    that the list of targeted applications has not been parsed yet. Setting it
+    to an empty dict prevents exceptions later on by stating that no supported
+    versions are available. If this didn't happen, it would be assumed that
+    compatibility (version-dependent) tests were reached before the install.rdf
+    was parsed. That would indicate that the validation process has encountered
+    an error elsewhere.
+    """
+
+    err = ErrorBundle()
+    orig_value = err.supported_versions = {"foo": ["bar"]}
+
+    # Test package to make sure has_install_rdf is set to True.
+    assert targetapp.test_targetedapplications(err, None) is None
+    # The supported versions list must match what was specified
+    assert err.supported_versions is orig_value
 
 
 def test_is_ff4():

--- a/validator/testcases/targetapplication.py
+++ b/validator/testcases/targetapplication.py
@@ -14,7 +14,8 @@ def test_targetedapplications(err, xpi_package=None):
 
     install = err.get_resource("install_rdf")
     if not install:
-        err.supported_versions = {}
+        if err.supported_versions is None:
+            err.supported_versions = {}
         return
 
     APPROVED_APPLICATIONS = validator.constants.APPROVED_APPLICATIONS
@@ -163,6 +164,7 @@ def test_targetedapplications(err, xpi_package=None):
         if key in APPLICATIONS:
             supports.append(APPLICATIONS[key])
     err.save_resource("supports", supports)
+
     if not err.supported_versions:  # if not set for compatibility
         err.supported_versions = all_supported_versions
 


### PR DESCRIPTION
The problem is long and difficult to explain, but there's some good documentation in the updated tests. Basically, the list of target applications was being overwritten along the line when it shouldn't have been. I updated the functionality and added a test to make sure that it isn't overwritten when it shouldn't be and update d the test to make sure that it is overwritten when it should be.
