### PR TITLE
Fixed traceback in bug 739715

### DIFF
--- a/tests/test_js_e4x.py
+++ b/tests/test_js_e4x.py
@@ -60,3 +60,15 @@ class TestE4X(TestCase):
         """)
         self.assert_silent()
 
+    def test_double_colon(self):
+        """
+        Test that assignmnts with a double colon on an E4X object don't cause a
+        traceback.
+        """
+        self.run_script("""
+        var req = <nsMessages:GetItem xmlns:nsMessages={nsMessages}
+                      xmlns:nsTypes={nsTypes}/>;
+        req::asdf.oijaewr::aasdf = "foo";
+        """)
+        self.assert_silent()
+

--- a/validator/testcases/javascript/traverser.py
+++ b/validator/testcases/javascript/traverser.py
@@ -110,10 +110,10 @@ class Traverser:
         "Finds a node's internal blocks and helps manage state."
 
         if node is None:
-            return None
+            return JSWrapper(JSObject(), traverser=self, dirty=True)
 
         # Simple caching to prevent retraversal
-        if "__traversal" in node:
+        if "__traversal" in node and node["__traversal"] is not None:
             return node["__traversal"]
 
         if isinstance(node, (str, unicode)):
@@ -187,6 +187,7 @@ class Traverser:
             return action_result
 
         node["__traversal"] = None
+        return JSWrapper(JSObject(), traverser=self, dirty=True)
 
     def _push_block_context(self):
         "Adds a block context to the current interpretation frame"


### PR DESCRIPTION
The problem was because E4X assignments expected a result but were not getting one. This shouldn't have tripped a problem, so I patched up the `None` leaks and it should be good to go now.
