### PR TITLE
Fixed bug 750352

### DIFF
--- a/tests/helper.py
+++ b/tests/helper.py
@@ -129,7 +129,7 @@ class TestCase(unittest.TestCase):
         """
         assert any(msg["id"] == errid for msg in
                    (self.err.errors + self.err.warnings + self.err.notices)), \
-                "%s was expected, but it was not found." % errid
+                "%s was expected, but it was not found." % repr(errid)
 
 
 class MockZipFile:

--- a/tests/test_js_wrappedjsobject.py
+++ b/tests/test_js_wrappedjsobject.py
@@ -30,6 +30,14 @@ class TestWrappedJSObject(TestCase):
         """)
         self.assert_wrappedjs_failure()
 
+    def test_global_unaffected(self):
+        """Test that globals aren't treated differently from non-globals."""
+        self.run_script("""
+            var x = XPCNativeWrapper.unwrap(unsafeWindow.foobar.zipzap[i]);
+            x.test();
+        """)
+        self.assert_failed(with_warnings=True)
+
     def test_recursive_assign(self):
         """
         Test that properties can't be assigned to the members of unwrapped

--- a/validator/testcases/javascript/call_definitions.py
+++ b/validator/testcases/javascript/call_definitions.py
@@ -748,7 +748,7 @@ def nsIMsgDatabase_changed(wrapper, arguments, traverser):
 
 def TB12_nsIImapProtocol_changed(wrapper, arguments, traverser):
     """
-    Flag use of nsIImapProtocol::Initialize and 
+    Flag use of nsIImapProtocol::Initialize and
     nsIImapIncomingServer::GetImapConnectionAndLoadUrl for incompatibility
     with Thunderbird 12.
     """
@@ -805,7 +805,12 @@ def js_wrap(wrapper, arguments, traverser):
     if obj.value is None:
         traverser._debug("WRAPPING OBJECT>>NOTHING TO WRAP")
         return JSWrapper(JSObject(), traverser=traverser)
-    obj.value.is_unwrapped = False
+
+    if obj.is_global:
+        obj.value["is_unwrapped"] = False
+    else:
+        obj.value.is_unwrapped = False
+
     return obj
 
 
@@ -820,6 +825,11 @@ def js_unwrap(wrapper, arguments, traverser):
     if obj.value is None:
         traverser._debug("UNWRAPPING OBJECT>>NOTHING TO UNWRAP")
         return JSWrapper(JSObject(unwrapped=True), traverser=traverser)
-    obj.value.is_unwrapped = True
+
+    if obj.is_global:
+        obj.value["is_unwrapped"] = True
+    else:
+        obj.value.is_unwrapped = True
+
     return obj
 


### PR DESCRIPTION
Globals weren't being accounted for when objects were being wrapped and unwrapped by `XPCNativeWrapper.unwrap`. This fixes that.
