### PR TITLE
HTML detection updates (bugs 735754 and 681811)

### DIFF
--- a/tests/test_js_instanceactions.py
+++ b/tests/test_js_instanceactions.py
@@ -77,3 +77,27 @@ def test_callexpression_argument_traversal():
     }});
     """).failed()
 
+
+def test_insertAdjacentHTML():
+    """Test that insertAdjacentHTML works the same as innerHTML."""
+
+    assert not _do_test_raw("""
+    var x = foo();
+    x.insertAdjacentHTML("foo bar", "<div></div>");
+    """).failed()
+
+    assert _do_test_raw("""
+    var x = foo();
+    x.insertAdjacentHTML("foo bar", "<div onclick=\\"foo\\"></div>");
+    """).failed()
+
+    # Test without declaration
+    assert _do_test_raw("""
+    x.insertAdjacentHTML("foo bar", "<div onclick=\\"foo\\"></div>");
+    """).failed()
+
+    assert _do_test_raw("""
+    var x = foo();
+    x.insertAdjacentHTML("foo bar", "x" + y);
+    """).failed()
+

--- a/tests/test_js_instanceproperties.py
+++ b/tests/test_js_instanceproperties.py
@@ -49,30 +49,6 @@ def test_outerHTML():
     """).failed()
 
 
-def test_innerAdjacentHTML():
-    """Test that innerAdjacentHTML works the same as innerHTML."""
-
-    assert not _do_test_raw("""
-    var x = foo();
-    x.innerAdjacentHTML = "<div></div>";
-    """).failed()
-
-    assert _do_test_raw("""
-    var x = foo();
-    x.innerAdjacentHTML = "<div onclick=\\"foo\\"></div>";
-    """).failed()
-
-    # Test without declaration
-    assert _do_test_raw("""
-    x.innerAdjacentHTML = "<div onclick=\\"foo\\"></div>";
-    """).failed()
-
-    assert _do_test_raw("""
-    var x = foo();
-    x.innerAdjacentHTML = "x" + y;
-    """).failed()
-
-
 def test_complex_innerHTML():
     """Tests that innerHTML can't be assigned an HTML chunk with bad code"""
 

--- a/validator/testcases/javascript/instanceactions.py
+++ b/validator/testcases/javascript/instanceactions.py
@@ -12,10 +12,11 @@ node
 
 import types
 
+import actions
 from validator.compat import FX10_DEFINITION
 from validator.constants import BUGZILLA_BUG
-import actions
 from jstypes import *
+from instanceproperties import _set_HTML_property
 
 
 def createElement(args, traverser, node, wrapper):
@@ -141,6 +142,19 @@ def nsIDOMFile_deprec(args, traverser, node, wrapper):
     cd_nsIDOMFile_deprec(None, [], traverser)
 
 
+def insertAdjacentHTML(args, traverser, node, wrapper):
+    """
+    Perfrom the same tests on content inserted into the DOM via
+    insertAdjacentHTML as we otherwise would for content inserted via the
+    various innerHTML/outerHTML properties.
+    """
+    if not args or len(args) < 2:
+        return
+
+    content = traverser._traverse_node(args[1])
+    _set_HTML_property("insertAdjacentHTML", content, traverser)
+
+
 def isSameNode(args, traverser, node, wrapper):
     """Raise an error when an add-on uses node.isSameNode(foo)."""
     traverser.err.error(
@@ -206,6 +220,7 @@ INSTANCE_DEFINITIONS = {"createElement": createElement,
                         "getAsBinary": nsIDOMFile_deprec,
                         "getAsDataURL": nsIDOMFile_deprec,
                         "getInterface": getInterface,
+                        "insertAdjacentHTML": insertAdjacentHTML,
                         "isSameNode": isSameNode,
                         "PageMod": PageMod,
                         "QueryInterface": QueryInterface,

--- a/validator/testcases/javascript/instanceproperties.py
+++ b/validator/testcases/javascript/instanceproperties.py
@@ -148,7 +148,6 @@ OBJECT_DEFINITIONS = {"_endMarker": {"get": startendMarker,
                                        "set": startendMarker},
                       "innerHTML": {"set": set_innerHTML},
                       "outerHTML": {"set": set_outerHTML},
-                      "innerAdjacentHTML": {"set": set_innerHTML},
                       "isElementContentWhitespace":
                           {"get": get_isElementContentWhitespace},
                       "xmlEncoding": _get_xml("xmlEncoding"),


### PR DESCRIPTION
- Flagging `outerHTML` in the same way as `innerHTML`; bug 735754
- Fixed `innerAdjacentHTML` mistake; bug 681811
