### PR TITLE
Remove corrupt ZIP considerations and bake them in.

### DIFF
--- a/tests/test_xpimanager.py
+++ b/tests/test_xpimanager.py
@@ -35,7 +35,6 @@ def test_valid_name():
     z = XPIManager(get_path('xpi/install_rdf_only.xpi'))
     contents = z.package_contents()
     assert 'install.rdf' in contents
-    assert z.test() == False
 
 
 def test_read_file():
@@ -55,16 +54,6 @@ def test_write_file():
             eq_(z.read(f), d.encode('utf-8'))
         finally:
             os.unlink(temp_fn)
-
-
-def test_bad_file():
-    """Tests that the XPI manager correctly reports a bad XPI file."""
-    try:
-        x = XPIManager(get_path('junk.xpi'))
-    except BadZipfile:
-        pass
-    x = XPIManager(get_path('corrupt.xpi'))
-    assert x.test()
 
 
 def test_missing_file():

--- a/validator/xpi.py
+++ b/validator/xpi.py
@@ -37,19 +37,6 @@ class XPIManager(object):
         """Get info on a single file."""
         return self.package_contents()[name]
 
-    def test(self):
-        """
-        Tests the validity and non-corruptness of the zip. Will return true on
-        failure.
-        """
-
-        # This guy tests the hashes of the content.
-        try:
-            output = self.zf.testzip()
-            return output is not None
-        except:
-            return True
-
     def package_contents(self):
         "Returns a dictionary of file information"
 


### PR DESCRIPTION
Corrupt ZIPs should be handled when they're encountered. We don't need
extra tests to fail the add-on if it is or contains a corrupt ZIP.
