### PR TITLE
Update Jetpack hashes to pick up 1.9rc1

### DIFF
--- a/validator/testcases/jetpack_data.txt
+++ b/validator/testcases/jetpack_data.txt
@@ -59,6 +59,7 @@
 ./doc/static-files/base.html 1.9b2 e6a4c929ed1cf16e2c22a3f5697093fda5630332bb299703f70ada6f7e616b0f
 ./doc/static-files/base.html 1.9b3 e6a4c929ed1cf16e2c22a3f5697093fda5630332bb299703f70ada6f7e616b0f
 ./doc/static-files/base.html 1.9-dev e6a4c929ed1cf16e2c22a3f5697093fda5630332bb299703f70ada6f7e616b0f
+./doc/static-files/base.html 1.9rc1 e6a4c929ed1cf16e2c22a3f5697093fda5630332bb299703f70ada6f7e616b0f
 ./doc/static-files/js/jquery.js 1.10-dev c8370a2d050359e9d505acc411e6f457a49b21360a21e6cbc9229bad3a767899
 ./doc/static-files/js/jquery.js 1.2.1 c8370a2d050359e9d505acc411e6f457a49b21360a21e6cbc9229bad3a767899
 ./doc/static-files/js/jquery.js 1.2.1rc1 c8370a2d050359e9d505acc411e6f457a49b21360a21e6cbc9229bad3a767899
@@ -120,6 +121,7 @@
 ./doc/static-files/js/jquery.js 1.9b2 c8370a2d050359e9d505acc411e6f457a49b21360a21e6cbc9229bad3a767899
 ./doc/static-files/js/jquery.js 1.9b3 c8370a2d050359e9d505acc411e6f457a49b21360a21e6cbc9229bad3a767899
 ./doc/static-files/js/jquery.js 1.9-dev c8370a2d050359e9d505acc411e6f457a49b21360a21e6cbc9229bad3a767899
+./doc/static-files/js/jquery.js 1.9rc1 c8370a2d050359e9d505acc411e6f457a49b21360a21e6cbc9229bad3a767899
 ./doc/static-files/js/main.js 1.10-dev 5b29116e1ebc64e7ca6e9df240512b3cf726d987a18ae0e9a0f531105b49a473
 ./doc/static-files/js/main.js 1.2.1 77c96828ef374649cb779c715e5b5906e5c206d9d230aa12e3719207303e6159
 ./doc/static-files/js/main.js 1.2.1rc1 77c96828ef374649cb779c715e5b5906e5c206d9d230aa12e3719207303e6159
@@ -181,6 +183,7 @@
 ./doc/static-files/js/main.js 1.9b2 5b29116e1ebc64e7ca6e9df240512b3cf726d987a18ae0e9a0f531105b49a473
 ./doc/static-files/js/main.js 1.9b3 5b29116e1ebc64e7ca6e9df240512b3cf726d987a18ae0e9a0f531105b49a473
 ./doc/static-files/js/main.js 1.9-dev 5b29116e1ebc64e7ca6e9df240512b3cf726d987a18ae0e9a0f531105b49a473
+./doc/static-files/js/main.js 1.9rc1 3222015db6cfd84d59df3fb00abb4c568b5cb7615df214d8be4420715ec52c85
 ./doc/static-files/syntaxhighlighter/scripts/shBrushCss.js 1.10-dev d3c494b68b64e24bdc66748471fe73d49f0d5402e02029fd6acad00e1a1bd5b8
 ./doc/static-files/syntaxhighlighter/scripts/shBrushCss.js 1.2.1 d3c494b68b64e24bdc66748471fe73d49f0d5402e02029fd6acad00e1a1bd5b8
 ./doc/static-files/syntaxhighlighter/scripts/shBrushCss.js 1.2.1rc1 d3c494b68b64e24bdc66748471fe73d49f0d5402e02029fd6acad00e1a1bd5b8
@@ -242,6 +245,7 @@
 ./doc/static-files/syntaxhighlighter/scripts/shBrushCss.js 1.9b2 d3c494b68b64e24bdc66748471fe73d49f0d5402e02029fd6acad00e1a1bd5b8
 ./doc/static-files/syntaxhighlighter/scripts/shBrushCss.js 1.9b3 d3c494b68b64e24bdc66748471fe73d49f0d5402e02029fd6acad00e1a1bd5b8
 ./doc/static-files/syntaxhighlighter/scripts/shBrushCss.js 1.9-dev d3c494b68b64e24bdc66748471fe73d49f0d5402e02029fd6acad00e1a1bd5b8
+./doc/static-files/syntaxhighlighter/scripts/shBrushCss.js 1.9rc1 d3c494b68b64e24bdc66748471fe73d49f0d5402e02029fd6acad00e1a1bd5b8
 ./doc/static-files/syntaxhighlighter/scripts/shBrushJScript.js 1.10-dev 3f534a9cb3030831626f875de5e69f72e1cc020db2761b6ac8a0186ef4fff512
 ./doc/static-files/syntaxhighlighter/scripts/shBrushJScript.js 1.2.1 3f534a9cb3030831626f875de5e69f72e1cc020db2761b6ac8a0186ef4fff512
 ./doc/static-files/syntaxhighlighter/scripts/shBrushJScript.js 1.2.1rc1 3f534a9cb3030831626f875de5e69f72e1cc020db2761b6ac8a0186ef4fff512
@@ -303,6 +307,7 @@
 ./doc/static-files/syntaxhighlighter/scripts/shBrushJScript.js 1.9b2 3f534a9cb3030831626f875de5e69f72e1cc020db2761b6ac8a0186ef4fff512
 ./doc/static-files/syntaxhighlighter/scripts/shBrushJScript.js 1.9b3 3f534a9cb3030831626f875de5e69f72e1cc020db2761b6ac8a0186ef4fff512
 ./doc/static-files/syntaxhighlighter/scripts/shBrushJScript.js 1.9-dev 3f534a9cb3030831626f875de5e69f72e1cc020db2761b6ac8a0186ef4fff512
+./doc/static-files/syntaxhighlighter/scripts/shBrushJScript.js 1.9rc1 3f534a9cb3030831626f875de5e69f72e1cc020db2761b6ac8a0186ef4fff512
 ./doc/static-files/syntaxhighlighter/scripts/shBrushXml.js 1.10-dev fb1fe49a904a4fda3ed82d2f88048b2ae88c217980b6bf2163c07f048663b43e
 ./doc/static-files/syntaxhighlighter/scripts/shBrushXml.js 1.2.1 fb1fe49a904a4fda3ed82d2f88048b2ae88c217980b6bf2163c07f048663b43e
 ./doc/static-files/syntaxhighlighter/scripts/shBrushXml.js 1.2.1rc1 fb1fe49a904a4fda3ed82d2f88048b2ae88c217980b6bf2163c07f048663b43e
@@ -364,6 +369,7 @@
 ./doc/static-files/syntaxhighlighter/scripts/shBrushXml.js 1.9b2 fb1fe49a904a4fda3ed82d2f88048b2ae88c217980b6bf2163c07f048663b43e
 ./doc/static-files/syntaxhighlighter/scripts/shBrushXml.js 1.9b3 fb1fe49a904a4fda3ed82d2f88048b2ae88c217980b6bf2163c07f048663b43e
 ./doc/static-files/syntaxhighlighter/scripts/shBrushXml.js 1.9-dev fb1fe49a904a4fda3ed82d2f88048b2ae88c217980b6bf2163c07f048663b43e
+./doc/static-files/syntaxhighlighter/scripts/shBrushXml.js 1.9rc1 fb1fe49a904a4fda3ed82d2f88048b2ae88c217980b6bf2163c07f048663b43e
 ./doc/static-files/syntaxhighlighter/scripts/shCore.js 1.10-dev 584a26f39cef2db245f41d4f6b8e3d0f7dfac5c06f0f454a49dfb94f6fb1517b
 ./doc/static-files/syntaxhighlighter/scripts/shCore.js 1.2.1 584a26f39cef2db245f41d4f6b8e3d0f7dfac5c06f0f454a49dfb94f6fb1517b
 ./doc/static-files/syntaxhighlighter/scripts/shCore.js 1.2.1rc1 584a26f39cef2db245f41d4f6b8e3d0f7dfac5c06f0f454a49dfb94f6fb1517b
@@ -425,6 +431,7 @@
 ./doc/static-files/syntaxhighlighter/scripts/shCore.js 1.9b2 584a26f39cef2db245f41d4f6b8e3d0f7dfac5c06f0f454a49dfb94f6fb1517b
 ./doc/static-files/syntaxhighlighter/scripts/shCore.js 1.9b3 584a26f39cef2db245f41d4f6b8e3d0f7dfac5c06f0f454a49dfb94f6fb1517b
 ./doc/static-files/syntaxhighlighter/scripts/shCore.js 1.9-dev 584a26f39cef2db245f41d4f6b8e3d0f7dfac5c06f0f454a49dfb94f6fb1517b
+./doc/static-files/syntaxhighlighter/scripts/shCore.js 1.9rc1 584a26f39cef2db245f41d4f6b8e3d0f7dfac5c06f0f454a49dfb94f6fb1517b
 ./examples/annotator/data/annotation/annotation.html 1.0b3 b17ea2aa879c8289646bd923017edb81a35d6f7b7679758f2774cd7523560c9d
 ./examples/annotator/data/annotation/annotation.html 1.0b3rc1 b17ea2aa879c8289646bd923017edb81a35d6f7b7679758f2774cd7523560c9d
 ./examples/annotator/data/annotation/annotation.html 1.0b3rc2 b17ea2aa879c8289646bd923017edb81a35d6f7b7679758f2774cd7523560c9d
@@ -509,6 +516,7 @@
 ./examples/annotator/data/annotation/annotation.html 1.9b2 6269072434ac90491de3d3aa3f5a90e59465321f700c66708b95d290447fe6e1
 ./examples/annotator/data/annotation/annotation.html 1.9b3 6269072434ac90491de3d3aa3f5a90e59465321f700c66708b95d290447fe6e1
 ./examples/annotator/data/annotation/annotation.html 1.9-dev 6269072434ac90491de3d3aa3f5a90e59465321f700c66708b95d290447fe6e1
+./examples/annotator/data/annotation/annotation.html 1.9rc1 6269072434ac90491de3d3aa3f5a90e59465321f700c66708b95d290447fe6e1
 ./examples/annotator/data/annotation/annotation.js 1.0 977981920eaf21ec84fddf2b1adfd8baa73eba94f0570c65ee9db63aaa663e8c
 ./examples/annotator/data/annotation/annotation.js 1.0b3 977981920eaf21ec84fddf2b1adfd8baa73eba94f0570c65ee9db63aaa663e8c
 ./examples/annotator/data/annotation/annotation.js 1.0b3rc1 977981920eaf21ec84fddf2b1adfd8baa73eba94f0570c65ee9db63aaa663e8c
@@ -593,6 +601,7 @@
 ./examples/annotator/data/annotation/annotation.js 1.9b2 737d23addaa93e271ee46a8f771bd5e5bbd9153218e0769195e3c5bdf691fa3a
 ./examples/annotator/data/annotation/annotation.js 1.9b3 737d23addaa93e271ee46a8f771bd5e5bbd9153218e0769195e3c5bdf691fa3a
 ./examples/annotator/data/annotation/annotation.js 1.9-dev 737d23addaa93e271ee46a8f771bd5e5bbd9153218e0769195e3c5bdf691fa3a
+./examples/annotator/data/annotation/annotation.js 1.9rc1 737d23addaa93e271ee46a8f771bd5e5bbd9153218e0769195e3c5bdf691fa3a
 ./examples/annotator/data/editor/annotation-editor.html 1.0 178ed370ea92edca77173851cd8ed77ca0cc930c4fede88507b561c25fa5d02f
 ./examples/annotator/data/editor/annotation-editor.html 1.0b3 88d278daa3ae7b59ea5c263f561492408c00e30c82eb83cec16611c007579be6
 ./examples/annotator/data/editor/annotation-editor.html 1.0b3rc1 88d278daa3ae7b59ea5c263f561492408c00e30c82eb83cec16611c007579be6
@@ -677,6 +686,7 @@
 ./examples/annotator/data/editor/annotation-editor.html 1.9b2 ec6cf35a3c689390c3c312e428464a29ace7c1b297c83444bc1ac3534b37bc85
 ./examples/annotator/data/editor/annotation-editor.html 1.9b3 ec6cf35a3c689390c3c312e428464a29ace7c1b297c83444bc1ac3534b37bc85
 ./examples/annotator/data/editor/annotation-editor.html 1.9-dev ec6cf35a3c689390c3c312e428464a29ace7c1b297c83444bc1ac3534b37bc85
+./examples/annotator/data/editor/annotation-editor.html 1.9rc1 ec6cf35a3c689390c3c312e428464a29ace7c1b297c83444bc1ac3534b37bc85
 ./examples/annotator/data/editor/annotation-editor.js 1.0 adc6a855798401d370979392b5833750de75fc841126cf8c50bff27ee67dcd80
 ./examples/annotator/data/editor/annotation-editor.js 1.0b3 a88a73c0452c2788e096867a0a7d3d9a0758e53f45dc735175b06c18e152a92a
 ./examples/annotator/data/editor/annotation-editor.js 1.0b3rc1 a88a73c0452c2788e096867a0a7d3d9a0758e53f45dc735175b06c18e152a92a
@@ -761,6 +771,7 @@
 ./examples/annotator/data/editor/annotation-editor.js 1.9b2 a4c6093ea7ca458dc7daa864771c500efb22bdb77b70559313e80c1d4a57b1d7
 ./examples/annotator/data/editor/annotation-editor.js 1.9b3 a4c6093ea7ca458dc7daa864771c500efb22bdb77b70559313e80c1d4a57b1d7
 ./examples/annotator/data/editor/annotation-editor.js 1.9-dev a4c6093ea7ca458dc7daa864771c500efb22bdb77b70559313e80c1d4a57b1d7
+./examples/annotator/data/editor/annotation-editor.js 1.9rc1 a4c6093ea7ca458dc7daa864771c500efb22bdb77b70559313e80c1d4a57b1d7
 ./examples/annotator/data/jquery-1.4.2.min.js 1.0b3 e23a2a4e2d7c2b41ebcdd8ffc0679df7140eb7f52e1eebabf827a88182643c59
 ./examples/annotator/data/jquery-1.4.2.min.js 1.0b3rc1 e23a2a4e2d7c2b41ebcdd8ffc0679df7140eb7f52e1eebabf827a88182643c59
 ./examples/annotator/data/jquery-1.4.2.min.js 1.0b3rc2 e23a2a4e2d7c2b41ebcdd8ffc0679df7140eb7f52e1eebabf827a88182643c59
@@ -845,6 +856,7 @@
 ./examples/annotator/data/jquery-1.4.2.min.js 1.9b2 e23a2a4e2d7c2b41ebcdd8ffc0679df7140eb7f52e1eebabf827a88182643c59
 ./examples/annotator/data/jquery-1.4.2.min.js 1.9b3 e23a2a4e2d7c2b41ebcdd8ffc0679df7140eb7f52e1eebabf827a88182643c59
 ./examples/annotator/data/jquery-1.4.2.min.js 1.9-dev e23a2a4e2d7c2b41ebcdd8ffc0679df7140eb7f52e1eebabf827a88182643c59
+./examples/annotator/data/jquery-1.4.2.min.js 1.9rc1 e23a2a4e2d7c2b41ebcdd8ffc0679df7140eb7f52e1eebabf827a88182643c59
 ./examples/annotator/data/list/annotation-list.html 1.0 8daa25e30c797b8932c4004d658080aa120b62a31c02a946f931c89cf462b158
 ./examples/annotator/data/list/annotation-list.html 1.0b3 8daa25e30c797b8932c4004d658080aa120b62a31c02a946f931c89cf462b158
 ./examples/annotator/data/list/annotation-list.html 1.0b3rc1 8daa25e30c797b8932c4004d658080aa120b62a31c02a946f931c89cf462b158
@@ -929,6 +941,7 @@
 ./examples/annotator/data/list/annotation-list.html 1.9b2 f55bb4153137b3e70e4aab762bc9d3b2e67e0ea7a58fedcb9de0cffaae8d8020
 ./examples/annotator/data/list/annotation-list.html 1.9b3 f55bb4153137b3e70e4aab762bc9d3b2e67e0ea7a58fedcb9de0cffaae8d8020
 ./examples/annotator/data/list/annotation-list.html 1.9-dev f55bb4153137b3e70e4aab762bc9d3b2e67e0ea7a58fedcb9de0cffaae8d8020
+./examples/annotator/data/list/annotation-list.html 1.9rc1 f55bb4153137b3e70e4aab762bc9d3b2e67e0ea7a58fedcb9de0cffaae8d8020
 ./examples/annotator/data/list/annotation-list.js 1.0 8c3ca2355a2817c3993ee179b7eda9bdd893e7cd375372feef2c0b5e8c6ac057
 ./examples/annotator/data/list/annotation-list.js 1.0b3 c29219989030545d1e11b53b7dc970b44cedf83be193b89b0839e74aba2a3ccd
 ./examples/annotator/data/list/annotation-list.js 1.0b3rc1 c29219989030545d1e11b53b7dc970b44cedf83be193b89b0839e74aba2a3ccd
@@ -1013,6 +1026,7 @@
 ./examples/annotator/data/list/annotation-list.js 1.9b2 dc873631c239fdf1fe0b7152b86f4f2a08d69a3bdcc9120f082177974ecc6ee9
 ./examples/annotator/data/list/annotation-list.js 1.9b3 dc873631c239fdf1fe0b7152b86f4f2a08d69a3bdcc9120f082177974ecc6ee9
 ./examples/annotator/data/list/annotation-list.js 1.9-dev dc873631c239fdf1fe0b7152b86f4f2a08d69a3bdcc9120f082177974ecc6ee9
+./examples/annotator/data/list/annotation-list.js 1.9rc1 dc873631c239fdf1fe0b7152b86f4f2a08d69a3bdcc9120f082177974ecc6ee9
 ./examples/annotator/data/matcher.js 1.0b3 35b3ebef31e1b3cb49d802df1a969adb835225263b20324f84dc8578e01b6427
 ./examples/annotator/data/matcher.js 1.0b3rc1 35b3ebef31e1b3cb49d802df1a969adb835225263b20324f84dc8578e01b6427
 ./examples/annotator/data/matcher.js 1.0b3rc2 35b3ebef31e1b3cb49d802df1a969adb835225263b20324f84dc8578e01b6427
@@ -1097,6 +1111,7 @@
 ./examples/annotator/data/matcher.js 1.9b2 eba3195fbbebbec8f3d95caeefcb38b9707695ae703cc4a996ce711a1a80f6c7
 ./examples/annotator/data/matcher.js 1.9b3 eba3195fbbebbec8f3d95caeefcb38b9707695ae703cc4a996ce711a1a80f6c7
 ./examples/annotator/data/matcher.js 1.9-dev eba3195fbbebbec8f3d95caeefcb38b9707695ae703cc4a996ce711a1a80f6c7
+./examples/annotator/data/matcher.js 1.9rc1 eba3195fbbebbec8f3d95caeefcb38b9707695ae703cc4a996ce711a1a80f6c7
 ./examples/annotator/data/selector.js 1.0b3 2fc4ccb19c34883890d06e89e533b131038f6b0a89b04626cc78a34ee0848c5e
 ./examples/annotator/data/selector.js 1.0b3rc1 2fc4ccb19c34883890d06e89e533b131038f6b0a89b04626cc78a34ee0848c5e
 ./examples/annotator/data/selector.js 1.0b3rc2 2fc4ccb19c34883890d06e89e533b131038f6b0a89b04626cc78a34ee0848c5e
@@ -1181,6 +1196,7 @@
 ./examples/annotator/data/selector.js 1.9b2 1ebfee6be4e9bbd0e145a60f2f9f3b06cdf8716b96b2cdc955d680c1b54072d4
 ./examples/annotator/data/selector.js 1.9b3 1ebfee6be4e9bbd0e145a60f2f9f3b06cdf8716b96b2cdc955d680c1b54072d4
 ./examples/annotator/data/selector.js 1.9-dev 1ebfee6be4e9bbd0e145a60f2f9f3b06cdf8716b96b2cdc955d680c1b54072d4
+./examples/annotator/data/selector.js 1.9rc1 1ebfee6be4e9bbd0e145a60f2f9f3b06cdf8716b96b2cdc955d680c1b54072d4
 ./examples/annotator/data/widget/widget.js 1.0b3 ad88daf7f7e094063cf7bc2c9041746e085b1ecee6e6e806cf26907fd6e858b9
 ./examples/annotator/data/widget/widget.js 1.0b3rc1 ad88daf7f7e094063cf7bc2c9041746e085b1ecee6e6e806cf26907fd6e858b9
 ./examples/annotator/data/widget/widget.js 1.0b3rc2 ad88daf7f7e094063cf7bc2c9041746e085b1ecee6e6e806cf26907fd6e858b9
@@ -1265,6 +1281,7 @@
 ./examples/annotator/data/widget/widget.js 1.9b2 858880bef09d2d16315b5dc8abf00e7af8c9e80d042300f4123aa1051fe853e9
 ./examples/annotator/data/widget/widget.js 1.9b3 858880bef09d2d16315b5dc8abf00e7af8c9e80d042300f4123aa1051fe853e9
 ./examples/annotator/data/widget/widget.js 1.9-dev 858880bef09d2d16315b5dc8abf00e7af8c9e80d042300f4123aa1051fe853e9
+./examples/annotator/data/widget/widget.js 1.9rc1 858880bef09d2d16315b5dc8abf00e7af8c9e80d042300f4123aa1051fe853e9
 ./examples/annotator/lib/main.js 1.0b3 8b96f5d48200cacf1156bd2e8c45a0abaf10e2b9ef2da98e518d14bfa4a23a98
 ./examples/annotator/lib/main.js 1.0b3rc1 8b96f5d48200cacf1156bd2e8c45a0abaf10e2b9ef2da98e518d14bfa4a23a98
 ./examples/annotator/lib/main.js 1.0b3rc2 8b96f5d48200cacf1156bd2e8c45a0abaf10e2b9ef2da98e518d14bfa4a23a98
@@ -1349,6 +1366,7 @@
 ./examples/annotator/lib/main.js 1.9b2 2d5531e839cba575e4db0a181042c3127a859a139ff37eea90fe7febbae353e1
 ./examples/annotator/lib/main.js 1.9b3 2d5531e839cba575e4db0a181042c3127a859a139ff37eea90fe7febbae353e1
 ./examples/annotator/lib/main.js 1.9-dev 2d5531e839cba575e4db0a181042c3127a859a139ff37eea90fe7febbae353e1
+./examples/annotator/lib/main.js 1.9rc1 2d5531e839cba575e4db0a181042c3127a859a139ff37eea90fe7febbae353e1
 ./examples/annotator/tests/test-main.js 1.0 03458bd6fb605f949cabdf300f1cb74cd572dfb77e5ab5e940eab889dc53081a
 ./examples/annotator/tests/test-main.js 1.0b3 03458bd6fb605f949cabdf300f1cb74cd572dfb77e5ab5e940eab889dc53081a
 ./examples/annotator/tests/test-main.js 1.0b3rc1 03458bd6fb605f949cabdf300f1cb74cd572dfb77e5ab5e940eab889dc53081a
@@ -1433,6 +1451,7 @@
 ./examples/annotator/tests/test-main.js 1.9b2 df5b8f3d3deb8dcb77290eecd68ade91722f5f2b9bc29d6b8c13bd814b95d4ec
 ./examples/annotator/tests/test-main.js 1.9b3 df5b8f3d3deb8dcb77290eecd68ade91722f5f2b9bc29d6b8c13bd814b95d4ec
 ./examples/annotator/tests/test-main.js 1.9-dev df5b8f3d3deb8dcb77290eecd68ade91722f5f2b9bc29d6b8c13bd814b95d4ec
+./examples/annotator/tests/test-main.js 1.9rc1 df5b8f3d3deb8dcb77290eecd68ade91722f5f2b9bc29d6b8c13bd814b95d4ec
 ./examples/library-detector/data/library-detector.js 1.10-dev 80204d13ff5430aaf8b05cd90d7febca0f49cfb23d24a8b1c9f59f15ac2a215e
 ./examples/library-detector/data/library-detector.js 1.3 80204d13ff5430aaf8b05cd90d7febca0f49cfb23d24a8b1c9f59f15ac2a215e
 ./examples/library-detector/data/library-detector.js 1.3rc1 80204d13ff5430aaf8b05cd90d7febca0f49cfb23d24a8b1c9f59f15ac2a215e
@@ -1483,6 +1502,7 @@
 ./examples/library-detector/data/library-detector.js 1.9b2 80204d13ff5430aaf8b05cd90d7febca0f49cfb23d24a8b1c9f59f15ac2a215e
 ./examples/library-detector/data/library-detector.js 1.9b3 80204d13ff5430aaf8b05cd90d7febca0f49cfb23d24a8b1c9f59f15ac2a215e
 ./examples/library-detector/data/library-detector.js 1.9-dev 80204d13ff5430aaf8b05cd90d7febca0f49cfb23d24a8b1c9f59f15ac2a215e
+./examples/library-detector/data/library-detector.js 1.9rc1 80204d13ff5430aaf8b05cd90d7febca0f49cfb23d24a8b1c9f59f15ac2a215e
 ./examples/library-detector/data/widget.js 1.10-dev 18ee0378aaa74c2838fd35db73afc161b437204952ad80d439d8324021a76a56
 ./examples/library-detector/data/widget.js 1.3 fc31fb11b0ec7cc7aa1be83dcf7f9698753602ae87d8affeee7ffb15ff6ace53
 ./examples/library-detector/data/widget.js 1.3rc1 fc31fb11b0ec7cc7aa1be83dcf7f9698753602ae87d8affeee7ffb15ff6ace53
@@ -1533,6 +1553,7 @@
 ./examples/library-detector/data/widget.js 1.9b2 18ee0378aaa74c2838fd35db73afc161b437204952ad80d439d8324021a76a56
 ./examples/library-detector/data/widget.js 1.9b3 18ee0378aaa74c2838fd35db73afc161b437204952ad80d439d8324021a76a56
 ./examples/library-detector/data/widget.js 1.9-dev 18ee0378aaa74c2838fd35db73afc161b437204952ad80d439d8324021a76a56
+./examples/library-detector/data/widget.js 1.9rc1 18ee0378aaa74c2838fd35db73afc161b437204952ad80d439d8324021a76a56
 ./examples/library-detector/lib/main.js 1.10-dev 4940f0c61b7b814d981433db4ee0659d75f672179ffce835cdbdca4ef7b46740
 ./examples/library-detector/lib/main.js 1.3 4f691d6314c9195d6ca4ca74b2a5f4e982303d2737828162d056c6746291b364
 ./examples/library-detector/lib/main.js 1.3rc1 4f691d6314c9195d6ca4ca74b2a5f4e982303d2737828162d056c6746291b364
@@ -1583,6 +1604,7 @@
 ./examples/library-detector/lib/main.js 1.9b2 4940f0c61b7b814d981433db4ee0659d75f672179ffce835cdbdca4ef7b46740
 ./examples/library-detector/lib/main.js 1.9b3 4940f0c61b7b814d981433db4ee0659d75f672179ffce835cdbdca4ef7b46740
 ./examples/library-detector/lib/main.js 1.9-dev 4940f0c61b7b814d981433db4ee0659d75f672179ffce835cdbdca4ef7b46740
+./examples/library-detector/lib/main.js 1.9rc1 4940f0c61b7b814d981433db4ee0659d75f672179ffce835cdbdca4ef7b46740
 ./examples/library-detector/test/test-main.js 1.10-dev df5b8f3d3deb8dcb77290eecd68ade91722f5f2b9bc29d6b8c13bd814b95d4ec
 ./examples/library-detector/test/test-main.js 1.3 03458bd6fb605f949cabdf300f1cb74cd572dfb77e5ab5e940eab889dc53081a
 ./examples/library-detector/test/test-main.js 1.3rc1 03458bd6fb605f949cabdf300f1cb74cd572dfb77e5ab5e940eab889dc53081a
@@ -1633,6 +1655,7 @@
 ./examples/library-detector/test/test-main.js 1.9b2 df5b8f3d3deb8dcb77290eecd68ade91722f5f2b9bc29d6b8c13bd814b95d4ec
 ./examples/library-detector/test/test-main.js 1.9b3 df5b8f3d3deb8dcb77290eecd68ade91722f5f2b9bc29d6b8c13bd814b95d4ec
 ./examples/library-detector/test/test-main.js 1.9-dev df5b8f3d3deb8dcb77290eecd68ade91722f5f2b9bc29d6b8c13bd814b95d4ec
+./examples/library-detector/test/test-main.js 1.9rc1 df5b8f3d3deb8dcb77290eecd68ade91722f5f2b9bc29d6b8c13bd814b95d4ec
 ./examples/reading-data/data/sample.html 0.3 a4a80585a5556f395dd9ee462ad804f2c8348eb3e29e3057c4f1636175c41852
 ./examples/reading-data/data/sample.html 0.3rc1 a4a80585a5556f395dd9ee462ad804f2c8348eb3e29e3057c4f1636175c41852
 ./examples/reading-data/data/sample.html 0.3rc2 a4a80585a5556f395dd9ee462ad804f2c8348eb3e29e3057c4f1636175c41852
@@ -1747,6 +1770,7 @@
 ./examples/reading-data/data/sample.html 1.9b2 d3d68506da5308fd0c05b3321fafd17671171229b3b6b3834dc7e0adc61127f4
 ./examples/reading-data/data/sample.html 1.9b3 d3d68506da5308fd0c05b3321fafd17671171229b3b6b3834dc7e0adc61127f4
 ./examples/reading-data/data/sample.html 1.9-dev d3d68506da5308fd0c05b3321fafd17671171229b3b6b3834dc7e0adc61127f4
+./examples/reading-data/data/sample.html 1.9rc1 d3d68506da5308fd0c05b3321fafd17671171229b3b6b3834dc7e0adc61127f4
 ./examples/reading-data/lib/main.js 0.3 977b8acbd17d695fa37088422f3e396a2da928b55c6ad5c3a34492a9a26609ab
 ./examples/reading-data/lib/main.js 0.3rc1 977b8acbd17d695fa37088422f3e396a2da928b55c6ad5c3a34492a9a26609ab
 ./examples/reading-data/lib/main.js 0.3rc2 977b8acbd17d695fa37088422f3e396a2da928b55c6ad5c3a34492a9a26609ab
@@ -1861,6 +1885,7 @@
 ./examples/reading-data/lib/main.js 1.9b2 0088a9a2e948218c7ec7542b966b5d5fc5637195f469228ef1f31dd4313881d6
 ./examples/reading-data/lib/main.js 1.9b3 0088a9a2e948218c7ec7542b966b5d5fc5637195f469228ef1f31dd4313881d6
 ./examples/reading-data/lib/main.js 1.9-dev 0088a9a2e948218c7ec7542b966b5d5fc5637195f469228ef1f31dd4313881d6
+./examples/reading-data/lib/main.js 1.9rc1 0088a9a2e948218c7ec7542b966b5d5fc5637195f469228ef1f31dd4313881d6
 ./examples/reading-data/tests/test-main.js 0.3 d0553778eedc4791a285bd3e5fa6c8b9c83a73c28d2be5a9f3d5f94e74f11f87
 ./examples/reading-data/tests/test-main.js 0.3rc1 d0553778eedc4791a285bd3e5fa6c8b9c83a73c28d2be5a9f3d5f94e74f11f87
 ./examples/reading-data/tests/test-main.js 0.3rc2 d0553778eedc4791a285bd3e5fa6c8b9c83a73c28d2be5a9f3d5f94e74f11f87
@@ -1975,6 +2000,7 @@
 ./examples/reading-data/tests/test-main.js 1.9b2 c3936760258f4b9d283d30e544a76db620b2b91abd8ff5f76ebcdce5b3a4fa4e
 ./examples/reading-data/tests/test-main.js 1.9b3 c3936760258f4b9d283d30e544a76db620b2b91abd8ff5f76ebcdce5b3a4fa4e
 ./examples/reading-data/tests/test-main.js 1.9-dev c3936760258f4b9d283d30e544a76db620b2b91abd8ff5f76ebcdce5b3a4fa4e
+./examples/reading-data/tests/test-main.js 1.9rc1 c3936760258f4b9d283d30e544a76db620b2b91abd8ff5f76ebcdce5b3a4fa4e
 ./examples/reddit-panel/data/jquery-1.4.2.min.js 0.7 e23a2a4e2d7c2b41ebcdd8ffc0679df7140eb7f52e1eebabf827a88182643c59
 ./examples/reddit-panel/data/jquery-1.4.2.min.js 0.7rc1 e23a2a4e2d7c2b41ebcdd8ffc0679df7140eb7f52e1eebabf827a88182643c59
 ./examples/reddit-panel/data/jquery-1.4.2.min.js 0.7rc2 e23a2a4e2d7c2b41ebcdd8ffc0679df7140eb7f52e1eebabf827a88182643c59
@@ -2073,6 +2099,7 @@
 ./examples/reddit-panel/data/jquery-1.4.4.min.js 1.9b2 517364f2d45162fb5037437b5b6cb953d00d9b2b3b79ba87d9fe57ea6ee6070c
 ./examples/reddit-panel/data/jquery-1.4.4.min.js 1.9b3 517364f2d45162fb5037437b5b6cb953d00d9b2b3b79ba87d9fe57ea6ee6070c
 ./examples/reddit-panel/data/jquery-1.4.4.min.js 1.9-dev 517364f2d45162fb5037437b5b6cb953d00d9b2b3b79ba87d9fe57ea6ee6070c
+./examples/reddit-panel/data/jquery-1.4.4.min.js 1.9rc1 517364f2d45162fb5037437b5b6cb953d00d9b2b3b79ba87d9fe57ea6ee6070c
 ./examples/reddit-panel/data/panel.js 0.7 1190dfdf70e04a386e5680b5cbef82759d6d99fb5e7430dd0d425e36aff3af57
 ./examples/reddit-panel/data/panel.js 0.7rc1 1190dfdf70e04a386e5680b5cbef82759d6d99fb5e7430dd0d425e36aff3af57
 ./examples/reddit-panel/data/panel.js 0.7rc2 1190dfdf70e04a386e5680b5cbef82759d6d99fb5e7430dd0d425e36aff3af57
@@ -2172,6 +2199,7 @@
 ./examples/reddit-panel/data/panel.js 1.9b2 5ee070b25f6bde36b569b9c931531f78b0c49dfd6776b84851b62ff9424e1fd5
 ./examples/reddit-panel/data/panel.js 1.9b3 5ee070b25f6bde36b569b9c931531f78b0c49dfd6776b84851b62ff9424e1fd5
 ./examples/reddit-panel/data/panel.js 1.9-dev 5ee070b25f6bde36b569b9c931531f78b0c49dfd6776b84851b62ff9424e1fd5
+./examples/reddit-panel/data/panel.js 1.9rc1 5ee070b25f6bde36b569b9c931531f78b0c49dfd6776b84851b62ff9424e1fd5
 ./examples/reddit-panel/lib/main.js 0.7 35343e9f7eb8c17f3ab0303c610f991ee407c299295b8f59be4789d793196cef
 ./examples/reddit-panel/lib/main.js 0.7rc1 35343e9f7eb8c17f3ab0303c610f991ee407c299295b8f59be4789d793196cef
 ./examples/reddit-panel/lib/main.js 0.7rc2 35343e9f7eb8c17f3ab0303c610f991ee407c299295b8f59be4789d793196cef
@@ -2271,6 +2299,7 @@
 ./examples/reddit-panel/lib/main.js 1.9b2 6f01afe7d564eae97987e466ab5560daec7346743cffffb9fcc11e6a5f9e370a
 ./examples/reddit-panel/lib/main.js 1.9b3 6f01afe7d564eae97987e466ab5560daec7346743cffffb9fcc11e6a5f9e370a
 ./examples/reddit-panel/lib/main.js 1.9-dev 6f01afe7d564eae97987e466ab5560daec7346743cffffb9fcc11e6a5f9e370a
+./examples/reddit-panel/lib/main.js 1.9rc1 6f01afe7d564eae97987e466ab5560daec7346743cffffb9fcc11e6a5f9e370a
 ./examples/reddit-panel/tests/test-main.js 1.0 2a2d30f11b60aa4a286f055b760c2d9c7480b1e09203e511a42e3adf6012de3e
 ./examples/reddit-panel/tests/test-main.js 1.0b2 2a2d30f11b60aa4a286f055b760c2d9c7480b1e09203e511a42e3adf6012de3e
 ./examples/reddit-panel/tests/test-main.js 1.0b2rc1 2a2d30f11b60aa4a286f055b760c2d9c7480b1e09203e511a42e3adf6012de3e
@@ -2357,6 +2386,7 @@
 ./examples/reddit-panel/tests/test-main.js 1.9b2 44f51b1db4cd8e3a74c0cdb24d03dec966ac48de6cd8e9a389c28208f6f15965
 ./examples/reddit-panel/tests/test-main.js 1.9b3 44f51b1db4cd8e3a74c0cdb24d03dec966ac48de6cd8e9a389c28208f6f15965
 ./examples/reddit-panel/tests/test-main.js 1.9-dev 44f51b1db4cd8e3a74c0cdb24d03dec966ac48de6cd8e9a389c28208f6f15965
+./examples/reddit-panel/tests/test-main.js 1.9rc1 44f51b1db4cd8e3a74c0cdb24d03dec966ac48de6cd8e9a389c28208f6f15965
 ./packages/addon-kit/data/index.html 1.10-dev 023b0fbb9bc21fb2b7e23b46ba4cc22735b723a36a3c7fdb7bc6b14bbaef9e9a
 ./packages/addon-kit/data/index.html 1.6.1 84f3fbfd0862c2bf560ceaa7c07471099fba3317f56e015f391789da21d9749f
 ./packages/addon-kit/data/index.html 1.6.1rc1 84f3fbfd0862c2bf560ceaa7c07471099fba3317f56e015f391789da21d9749f
@@ -2385,6 +2415,7 @@
 ./packages/addon-kit/data/index.html 1.9b2 023b0fbb9bc21fb2b7e23b46ba4cc22735b723a36a3c7fdb7bc6b14bbaef9e9a
 ./packages/addon-kit/data/index.html 1.9b3 023b0fbb9bc21fb2b7e23b46ba4cc22735b723a36a3c7fdb7bc6b14bbaef9e9a
 ./packages/addon-kit/data/index.html 1.9-dev 84f3fbfd0862c2bf560ceaa7c07471099fba3317f56e015f391789da21d9749f
+./packages/addon-kit/data/index.html 1.9rc1 023b0fbb9bc21fb2b7e23b46ba4cc22735b723a36a3c7fdb7bc6b14bbaef9e9a
 ./packages/addon-kit/data/test-context-menu.js 1.10-dev 793608c2af39121ae0542b7a324c38ec2b2a5bb0fe67753575417ee6596488c5
 ./packages/addon-kit/data/test-context-menu.js 1.5 793608c2af39121ae0542b7a324c38ec2b2a5bb0fe67753575417ee6596488c5
 ./packages/addon-kit/data/test-context-menu.js 1.5b1 793608c2af39121ae0542b7a324c38ec2b2a5bb0fe67753575417ee6596488c5
@@ -2420,6 +2451,7 @@
 ./packages/addon-kit/data/test-context-menu.js 1.9b2 793608c2af39121ae0542b7a324c38ec2b2a5bb0fe67753575417ee6596488c5
 ./packages/addon-kit/data/test-context-menu.js 1.9b3 793608c2af39121ae0542b7a324c38ec2b2a5bb0fe67753575417ee6596488c5
 ./packages/addon-kit/data/test-context-menu.js 1.9-dev 793608c2af39121ae0542b7a324c38ec2b2a5bb0fe67753575417ee6596488c5
+./packages/addon-kit/data/test-context-menu.js 1.9rc1 793608c2af39121ae0542b7a324c38ec2b2a5bb0fe67753575417ee6596488c5
 ./packages/addon-kit/data/test.html 0.9 c9242aa167cb7ae0ead5b1f3fd7d2d1b188c17e29d582efa7108b1dc688fe01e
 ./packages/addon-kit/data/test.html 0.9rc1 c9242aa167cb7ae0ead5b1f3fd7d2d1b188c17e29d582efa7108b1dc688fe01e
 ./packages/addon-kit/data/test.html 0.9rc2 c9242aa167cb7ae0ead5b1f3fd7d2d1b188c17e29d582efa7108b1dc688fe01e
@@ -2514,6 +2546,7 @@
 ./packages/addon-kit/data/test.html 1.9b2 6c905849d74f8f92d6157e9e599eff6c9b541a4d7e99368c912b21a8bfffc3e4
 ./packages/addon-kit/data/test.html 1.9b3 6c905849d74f8f92d6157e9e599eff6c9b541a4d7e99368c912b21a8bfffc3e4
 ./packages/addon-kit/data/test.html 1.9-dev 22675e9cff53d318b0cb1467f35f42bf8a6fc59f51359acc20494b0e333a701a
+./packages/addon-kit/data/test.html 1.9rc1 6c905849d74f8f92d6157e9e599eff6c9b541a4d7e99368c912b21a8bfffc3e4
 ./packages/addon-kit/data/test-localization.html 1.10-dev 3e28aab57d74a45bde265b378279905c2280dd142999739fbd65a85ee589d573
 ./packages/addon-kit/data/test-localization.html 1.8.1 3e28aab57d74a45bde265b378279905c2280dd142999739fbd65a85ee589d573
 ./packages/addon-kit/data/test-localization.html 1.8.2 3e28aab57d74a45bde265b378279905c2280dd142999739fbd65a85ee589d573
@@ -2528,6 +2561,7 @@
 ./packages/addon-kit/data/test-localization.html 1.9b2 3e28aab57d74a45bde265b378279905c2280dd142999739fbd65a85ee589d573
 ./packages/addon-kit/data/test-localization.html 1.9b3 3e28aab57d74a45bde265b378279905c2280dd142999739fbd65a85ee589d573
 ./packages/addon-kit/data/test-localization.html 1.9-dev 27c12b87363504a12217f240ad76ae563636d92fded8bbec4a466dbd6ca5234d
+./packages/addon-kit/data/test-localization.html 1.9rc1 3e28aab57d74a45bde265b378279905c2280dd142999739fbd65a85ee589d573
 ./packages/addon-kit/data/test-page-mod.html 1.10-dev aca46e7c00f99122a2df38c9bdf20e193967e7d086310f6fba6663c24ee9f017
 ./packages/addon-kit/data/test-page-mod.html 1.1 3e3e7a04ca3b1183f4b52ff0d5d0ad4957e2c180f14fce0fb431b9433ac3cf71
 ./packages/addon-kit/data/test-page-mod.html 1.1b1 3e3e7a04ca3b1183f4b52ff0d5d0ad4957e2c180f14fce0fb431b9433ac3cf71
@@ -2593,6 +2627,7 @@
 ./packages/addon-kit/data/test-page-mod.html 1.9b2 aca46e7c00f99122a2df38c9bdf20e193967e7d086310f6fba6663c24ee9f017
 ./packages/addon-kit/data/test-page-mod.html 1.9b3 aca46e7c00f99122a2df38c9bdf20e193967e7d086310f6fba6663c24ee9f017
 ./packages/addon-kit/data/test-page-mod.html 1.9-dev a27bc89750f0cc7a16546e58caaa8441bf14bff432057cc5ca3f79310024ddf1
+./packages/addon-kit/data/test-page-mod.html 1.9rc1 aca46e7c00f99122a2df38c9bdf20e193967e7d086310f6fba6663c24ee9f017
 ./packages/addon-kit/data/test-page-worker.html 0.9 b98da34bd7eb596f1502c990e532f28fe8d396c14f56efabb0e9598ad0938f7c
 ./packages/addon-kit/data/test-page-worker.html 0.9rc1 b98da34bd7eb596f1502c990e532f28fe8d396c14f56efabb0e9598ad0938f7c
 ./packages/addon-kit/data/test-page-worker.html 0.9rc2 b98da34bd7eb596f1502c990e532f28fe8d396c14f56efabb0e9598ad0938f7c
@@ -2687,6 +2722,7 @@
 ./packages/addon-kit/data/test-page-worker.html 1.9b2 66730d403de6e65e542f814275892ce840e409549f89ddd473473e609a4d51c1
 ./packages/addon-kit/data/test-page-worker.html 1.9b3 66730d403de6e65e542f814275892ce840e409549f89ddd473473e609a4d51c1
 ./packages/addon-kit/data/test-page-worker.html 1.9-dev cd88e93fd357621f491f6b4292a5de9180ce3806bb47d7716ca698e36671e030
+./packages/addon-kit/data/test-page-worker.html 1.9rc1 66730d403de6e65e542f814275892ce840e409549f89ddd473473e609a4d51c1
 ./packages/addon-kit/data/test-page-worker.js 0.9 b713b1ca147db2d0672d18071caaabbfe1dc0f67c67d31a3a93d5f003b49e3ee
 ./packages/addon-kit/data/test-page-worker.js 0.9rc1 b713b1ca147db2d0672d18071caaabbfe1dc0f67c67d31a3a93d5f003b49e3ee
 ./packages/addon-kit/data/test-page-worker.js 0.9rc2 b713b1ca147db2d0672d18071caaabbfe1dc0f67c67d31a3a93d5f003b49e3ee
@@ -2781,6 +2817,7 @@
 ./packages/addon-kit/data/test-page-worker.js 1.9b2 5f0206941901ae74b5417ab3244dbd55ba5de93918de5422901d92037c709e5c
 ./packages/addon-kit/data/test-page-worker.js 1.9b3 5f0206941901ae74b5417ab3244dbd55ba5de93918de5422901d92037c709e5c
 ./packages/addon-kit/data/test-page-worker.js 1.9-dev 5f0206941901ae74b5417ab3244dbd55ba5de93918de5422901d92037c709e5c
+./packages/addon-kit/data/test-page-worker.js 1.9rc1 5f0206941901ae74b5417ab3244dbd55ba5de93918de5422901d92037c709e5c
 ./packages/addon-kit/lib/addon-page.js 1.10-dev fece547d7dc77a1a6f89e67aabedf70850827f934dfef1e20a7facdf890a1baf
 ./packages/addon-kit/lib/addon-page.js 1.6.1 8cccc558ffbae7ad10707f2c7dcabb40cccc529049d8db508f6d4ca068007a5a
 ./packages/addon-kit/lib/addon-page.js 1.6.1rc1 8cccc558ffbae7ad10707f2c7dcabb40cccc529049d8db508f6d4ca068007a5a
@@ -2809,6 +2846,7 @@
 ./packages/addon-kit/lib/addon-page.js 1.9b2 fece547d7dc77a1a6f89e67aabedf70850827f934dfef1e20a7facdf890a1baf
 ./packages/addon-kit/lib/addon-page.js 1.9b3 fece547d7dc77a1a6f89e67aabedf70850827f934dfef1e20a7facdf890a1baf
 ./packages/addon-kit/lib/addon-page.js 1.9-dev 6d888116523bebbdbb428f3fad028aa97346e1fbe0e7fef8973ddef64b4c0da4
+./packages/addon-kit/lib/addon-page.js 1.9rc1 fece547d7dc77a1a6f89e67aabedf70850827f934dfef1e20a7facdf890a1baf
 ./packages/addon-kit/lib/clipboard.js 0.9 78f74580a08e0c5bcc43787fed7eaba7fc025354e02ba7f74bcbf3949c047546
 ./packages/addon-kit/lib/clipboard.js 0.9rc1 78f74580a08e0c5bcc43787fed7eaba7fc025354e02ba7f74bcbf3949c047546
 ./packages/addon-kit/lib/clipboard.js 0.9rc2 78f74580a08e0c5bcc43787fed7eaba7fc025354e02ba7f74bcbf3949c047546
@@ -2903,6 +2941,7 @@
 ./packages/addon-kit/lib/clipboard.js 1.9b2 7687058dc32d82ac846d68c4e4154bb2e384911397f6a09ed0fb176487327a20
 ./packages/addon-kit/lib/clipboard.js 1.9b3 7687058dc32d82ac846d68c4e4154bb2e384911397f6a09ed0fb176487327a20
 ./packages/addon-kit/lib/clipboard.js 1.9-dev 6c7ffd2a0a7fc13e0a0bac1544c742e62ebad34e6aba3d69ec77a0436384d70b
+./packages/addon-kit/lib/clipboard.js 1.9rc1 7687058dc32d82ac846d68c4e4154bb2e384911397f6a09ed0fb176487327a20
 ./packages/addon-kit/lib/context-menu.js 0.9 65481150116da78bcca446fb949aab72382f42f5ac1136f3b6f55716a4c2952d
 ./packages/addon-kit/lib/context-menu.js 0.9rc1 65481150116da78bcca446fb949aab72382f42f5ac1136f3b6f55716a4c2952d
 ./packages/addon-kit/lib/context-menu.js 0.9rc2 65481150116da78bcca446fb949aab72382f42f5ac1136f3b6f55716a4c2952d
@@ -2997,6 +3036,7 @@
 ./packages/addon-kit/lib/context-menu.js 1.9b2 4d8310b44a615c7955a03f95685aaf9863b21299e070ecd84bd3b1da4c03e958
 ./packages/addon-kit/lib/context-menu.js 1.9b3 4d8310b44a615c7955a03f95685aaf9863b21299e070ecd84bd3b1da4c03e958
 ./packages/addon-kit/lib/context-menu.js 1.9-dev 2def7b8474b943584c6a68ecd4935c73d8ed74d26e6cea1e3009f8857917c630
+./packages/addon-kit/lib/context-menu.js 1.9rc1 4d8310b44a615c7955a03f95685aaf9863b21299e070ecd84bd3b1da4c03e958
 ./packages/addon-kit/lib/hotkeys.js 1.0 8577a1afa95f2f2f9fa3f3d406dc65c2c0c8fbe308f3134106794f8bc2451d45
 ./packages/addon-kit/lib/hotkeys.js 1.0b5 8577a1afa95f2f2f9fa3f3d406dc65c2c0c8fbe308f3134106794f8bc2451d45
 ./packages/addon-kit/lib/hotkeys.js 1.0b5rc1 8577a1afa95f2f2f9fa3f3d406dc65c2c0c8fbe308f3134106794f8bc2451d45
@@ -3072,6 +3112,7 @@
 ./packages/addon-kit/lib/hotkeys.js 1.9b2 47954c559c2ca2b1b61ce666fb9175b884f509f3e49c2f20bc128b96925d0fca
 ./packages/addon-kit/lib/hotkeys.js 1.9b3 47954c559c2ca2b1b61ce666fb9175b884f509f3e49c2f20bc128b96925d0fca
 ./packages/addon-kit/lib/hotkeys.js 1.9-dev 47954c559c2ca2b1b61ce666fb9175b884f509f3e49c2f20bc128b96925d0fca
+./packages/addon-kit/lib/hotkeys.js 1.9rc1 47954c559c2ca2b1b61ce666fb9175b884f509f3e49c2f20bc128b96925d0fca
 ./packages/addon-kit/lib/l10n.js 1.10-dev 6af8f76043427f8eeb44965f97ad71641b1ad3bb820f1f38cb475d958d7837ca
 ./packages/addon-kit/lib/l10n.js 1.5 af69d4d881d1f1bebf19ce4cd6e62b19c71cc26a5abd143b5ebeb69ab55ebfd7
 ./packages/addon-kit/lib/l10n.js 1.5b1 af69d4d881d1f1bebf19ce4cd6e62b19c71cc26a5abd143b5ebeb69ab55ebfd7
@@ -3107,6 +3148,7 @@
 ./packages/addon-kit/lib/l10n.js 1.9b2 6af8f76043427f8eeb44965f97ad71641b1ad3bb820f1f38cb475d958d7837ca
 ./packages/addon-kit/lib/l10n.js 1.9b3 6af8f76043427f8eeb44965f97ad71641b1ad3bb820f1f38cb475d958d7837ca
 ./packages/addon-kit/lib/l10n.js 1.9-dev 6af8f76043427f8eeb44965f97ad71641b1ad3bb820f1f38cb475d958d7837ca
+./packages/addon-kit/lib/l10n.js 1.9rc1 6af8f76043427f8eeb44965f97ad71641b1ad3bb820f1f38cb475d958d7837ca
 ./packages/addon-kit/lib/localization.js 0.9 e6987604d2bca462bd33ca2948e4094ca3ec14c5365891315e73011c255979b6
 ./packages/addon-kit/lib/localization.js 0.9rc1 e6987604d2bca462bd33ca2948e4094ca3ec14c5365891315e73011c255979b6
 ./packages/addon-kit/lib/localization.js 0.9rc2 e6987604d2bca462bd33ca2948e4094ca3ec14c5365891315e73011c255979b6
@@ -3204,6 +3246,7 @@
 ./packages/addon-kit/lib/notifications.js 1.9b2 2917632f714b9fb1f81201c90c99041e3fc802c41541df177910c4628e67e7ad
 ./packages/addon-kit/lib/notifications.js 1.9b3 2917632f714b9fb1f81201c90c99041e3fc802c41541df177910c4628e67e7ad
 ./packages/addon-kit/lib/notifications.js 1.9-dev 2917632f714b9fb1f81201c90c99041e3fc802c41541df177910c4628e67e7ad
+./packages/addon-kit/lib/notifications.js 1.9rc1 2917632f714b9fb1f81201c90c99041e3fc802c41541df177910c4628e67e7ad
 ./packages/addon-kit/lib/page-mod.js 0.9 25481a7f665d4e60ed77d2515d1d505013b345db62a6a9dabeb13aba9ea4f898
 ./packages/addon-kit/lib/page-mod.js 0.9rc1 25481a7f665d4e60ed77d2515d1d505013b345db62a6a9dabeb13aba9ea4f898
 ./packages/addon-kit/lib/page-mod.js 0.9rc2 25481a7f665d4e60ed77d2515d1d505013b345db62a6a9dabeb13aba9ea4f898
@@ -3298,6 +3341,7 @@
 ./packages/addon-kit/lib/page-mod.js 1.9b2 49834272cb50937037b183f92dc45f14f2c66bd25d5af486021d92d44e2434ff
 ./packages/addon-kit/lib/page-mod.js 1.9b3 49834272cb50937037b183f92dc45f14f2c66bd25d5af486021d92d44e2434ff
 ./packages/addon-kit/lib/page-mod.js 1.9-dev e4c5232deca5cf74f0a298a705950e24a9e4c415f43890e251e54dd2a4288d14
+./packages/addon-kit/lib/page-mod.js 1.9rc1 49834272cb50937037b183f92dc45f14f2c66bd25d5af486021d92d44e2434ff
 ./packages/addon-kit/lib/page-worker.js 0.9 54144378f8b17c7d10e139ca764df194b98bb037d8d7828f5b9cf81098aa7d0f
 ./packages/addon-kit/lib/page-worker.js 0.9rc1 54144378f8b17c7d10e139ca764df194b98bb037d8d7828f5b9cf81098aa7d0f
 ./packages/addon-kit/lib/page-worker.js 0.9rc2 54144378f8b17c7d10e139ca764df194b98bb037d8d7828f5b9cf81098aa7d0f
@@ -3392,6 +3436,7 @@
 ./packages/addon-kit/lib/page-worker.js 1.9b2 d435a00f57a919645ee4638dd632c73980a63f79fbc00e183798eb6410e650cf
 ./packages/addon-kit/lib/page-worker.js 1.9b3 d435a00f57a919645ee4638dd632c73980a63f79fbc00e183798eb6410e650cf
 ./packages/addon-kit/lib/page-worker.js 1.9-dev d435a00f57a919645ee4638dd632c73980a63f79fbc00e183798eb6410e650cf
+./packages/addon-kit/lib/page-worker.js 1.9rc1 d435a00f57a919645ee4638dd632c73980a63f79fbc00e183798eb6410e650cf
 ./packages/addon-kit/lib/panel.js 0.9 a9d7427d92205076435889d83663d0e500c27e8072a10fd5075b65e1e4371d26
 ./packages/addon-kit/lib/panel.js 0.9rc1 a9d7427d92205076435889d83663d0e500c27e8072a10fd5075b65e1e4371d26
 ./packages/addon-kit/lib/panel.js 0.9rc2 a9d7427d92205076435889d83663d0e500c27e8072a10fd5075b65e1e4371d26
@@ -3486,6 +3531,7 @@
 ./packages/addon-kit/lib/panel.js 1.9b2 884ac0eccf75ed4420a1432c5f0a4ed38f11f5d04924d6913bd63652fef57f0d
 ./packages/addon-kit/lib/panel.js 1.9b3 884ac0eccf75ed4420a1432c5f0a4ed38f11f5d04924d6913bd63652fef57f0d
 ./packages/addon-kit/lib/panel.js 1.9-dev 0acd2cbf8c77c6c0174f05716746a294d428b701f06a6db69c55d9ab244a94ef
+./packages/addon-kit/lib/panel.js 1.9rc1 884ac0eccf75ed4420a1432c5f0a4ed38f11f5d04924d6913bd63652fef57f0d
 ./packages/addon-kit/lib/passwords.js 1.0 222cea3968ba2ea49c5db1cc4969c56fe5e34dd7d316c4858a68cdc81b7b1eab
 ./packages/addon-kit/lib/passwords.js 1.0b4.1 961e296634110085838120a7349d7b5d4bd8c3b20e86c72fa703d7553d4b6fc3
 ./packages/addon-kit/lib/passwords.js 1.0b4 961e296634110085838120a7349d7b5d4bd8c3b20e86c72fa703d7553d4b6fc3
@@ -3566,6 +3612,7 @@
 ./packages/addon-kit/lib/passwords.js 1.9b2 1da162b205a026bb703f264db93fc68f955e1d901dbf508f2ffcabf3efa0b2f2
 ./packages/addon-kit/lib/passwords.js 1.9b3 1da162b205a026bb703f264db93fc68f955e1d901dbf508f2ffcabf3efa0b2f2
 ./packages/addon-kit/lib/passwords.js 1.9-dev 1da162b205a026bb703f264db93fc68f955e1d901dbf508f2ffcabf3efa0b2f2
+./packages/addon-kit/lib/passwords.js 1.9rc1 1da162b205a026bb703f264db93fc68f955e1d901dbf508f2ffcabf3efa0b2f2
 ./packages/addon-kit/lib/private-browsing.js 0.9 a62c37d3e7823d187c313cfe71dcfb8a86fca5254239af324b8ce605c20e9f48
 ./packages/addon-kit/lib/private-browsing.js 0.9rc1 a62c37d3e7823d187c313cfe71dcfb8a86fca5254239af324b8ce605c20e9f48
 ./packages/addon-kit/lib/private-browsing.js 0.9rc2 a62c37d3e7823d187c313cfe71dcfb8a86fca5254239af324b8ce605c20e9f48
@@ -3660,6 +3707,7 @@
 ./packages/addon-kit/lib/private-browsing.js 1.9b2 b2dbc33be5f756f52948b878a7ac60c75f8d6b7ef644bf79e97f303a46961111
 ./packages/addon-kit/lib/private-browsing.js 1.9b3 b2dbc33be5f756f52948b878a7ac60c75f8d6b7ef644bf79e97f303a46961111
 ./packages/addon-kit/lib/private-browsing.js 1.9-dev b2dbc33be5f756f52948b878a7ac60c75f8d6b7ef644bf79e97f303a46961111
+./packages/addon-kit/lib/private-browsing.js 1.9rc1 b2dbc33be5f756f52948b878a7ac60c75f8d6b7ef644bf79e97f303a46961111
 ./packages/addon-kit/lib/request.js 0.9 374659030a8ee251cae919ed94e29db3d2441ba56e1c8a8d95b0fd3e5c98d824
 ./packages/addon-kit/lib/request.js 0.9rc1 374659030a8ee251cae919ed94e29db3d2441ba56e1c8a8d95b0fd3e5c98d824
 ./packages/addon-kit/lib/request.js 0.9rc2 374659030a8ee251cae919ed94e29db3d2441ba56e1c8a8d95b0fd3e5c98d824
@@ -3754,6 +3802,7 @@
 ./packages/addon-kit/lib/request.js 1.9b2 3635ae58dcb3a406e25e5ad5dcd0d2ccbcd4ee3e7c4e713ea3934766c37c874c
 ./packages/addon-kit/lib/request.js 1.9b3 3635ae58dcb3a406e25e5ad5dcd0d2ccbcd4ee3e7c4e713ea3934766c37c874c
 ./packages/addon-kit/lib/request.js 1.9-dev 3635ae58dcb3a406e25e5ad5dcd0d2ccbcd4ee3e7c4e713ea3934766c37c874c
+./packages/addon-kit/lib/request.js 1.9rc1 3635ae58dcb3a406e25e5ad5dcd0d2ccbcd4ee3e7c4e713ea3934766c37c874c
 ./packages/addon-kit/lib/selection.js 0.9 1c2daeea663998a1f12ca49957c37c909787a34accb92e2626b8a5fcb8e03a93
 ./packages/addon-kit/lib/selection.js 0.9rc1 1c2daeea663998a1f12ca49957c37c909787a34accb92e2626b8a5fcb8e03a93
 ./packages/addon-kit/lib/selection.js 0.9rc2 1c2daeea663998a1f12ca49957c37c909787a34accb92e2626b8a5fcb8e03a93
@@ -3848,6 +3897,7 @@
 ./packages/addon-kit/lib/selection.js 1.9b2 396889065e9d1e8c93f9f3d387ef1c3adba7bf251614be941d949a75a7788eca
 ./packages/addon-kit/lib/selection.js 1.9b3 396889065e9d1e8c93f9f3d387ef1c3adba7bf251614be941d949a75a7788eca
 ./packages/addon-kit/lib/selection.js 1.9-dev 396889065e9d1e8c93f9f3d387ef1c3adba7bf251614be941d949a75a7788eca
+./packages/addon-kit/lib/selection.js 1.9rc1 396889065e9d1e8c93f9f3d387ef1c3adba7bf251614be941d949a75a7788eca
 ./packages/addon-kit/lib/simple-prefs.js 1.10-dev 27b7b97705c6099b2dba95d0d6438dad9a268afba845955484385b268455356c
 ./packages/addon-kit/lib/simple-prefs.js 1.4.1 7c44b21bf8bddabf0b675032283fa82b9a7434e673f4b53f0097c40bc3130456
 ./packages/addon-kit/lib/simple-prefs.js 1.4.2 7c44b21bf8bddabf0b675032283fa82b9a7434e673f4b53f0097c40bc3130456
@@ -3896,6 +3946,7 @@
 ./packages/addon-kit/lib/simple-prefs.js 1.9b2 27b7b97705c6099b2dba95d0d6438dad9a268afba845955484385b268455356c
 ./packages/addon-kit/lib/simple-prefs.js 1.9b3 27b7b97705c6099b2dba95d0d6438dad9a268afba845955484385b268455356c
 ./packages/addon-kit/lib/simple-prefs.js 1.9-dev ba8715435701cb985c849c5ac187fd7004aba7bb6ec8c6526743963142ef9829
+./packages/addon-kit/lib/simple-prefs.js 1.9rc1 27b7b97705c6099b2dba95d0d6438dad9a268afba845955484385b268455356c
 ./packages/addon-kit/lib/simple-storage.js 0.9 1e45cfe7e52078340f0c16438fbaaf2cb17b066365cc8b38a3d0b6909758bd7a
 ./packages/addon-kit/lib/simple-storage.js 0.9rc1 1e45cfe7e52078340f0c16438fbaaf2cb17b066365cc8b38a3d0b6909758bd7a
 ./packages/addon-kit/lib/simple-storage.js 0.9rc2 1e45cfe7e52078340f0c16438fbaaf2cb17b066365cc8b38a3d0b6909758bd7a
@@ -3990,6 +4041,7 @@
 ./packages/addon-kit/lib/simple-storage.js 1.9b2 7ab9cfa0f6ac65ea6179658fa935101e50a1c3fd510e0875594e1c44ffe2386e
 ./packages/addon-kit/lib/simple-storage.js 1.9b3 7ab9cfa0f6ac65ea6179658fa935101e50a1c3fd510e0875594e1c44ffe2386e
 ./packages/addon-kit/lib/simple-storage.js 1.9-dev 7ab9cfa0f6ac65ea6179658fa935101e50a1c3fd510e0875594e1c44ffe2386e
+./packages/addon-kit/lib/simple-storage.js 1.9rc1 7ab9cfa0f6ac65ea6179658fa935101e50a1c3fd510e0875594e1c44ffe2386e
 ./packages/addon-kit/lib/tabs.js 0.9 15a9bf420551702b16667da3c52d26c07ddc852b35a6437eb98167a8a53a46ec
 ./packages/addon-kit/lib/tabs.js 0.9rc1 15a9bf420551702b16667da3c52d26c07ddc852b35a6437eb98167a8a53a46ec
 ./packages/addon-kit/lib/tabs.js 0.9rc2 15a9bf420551702b16667da3c52d26c07ddc852b35a6437eb98167a8a53a46ec
@@ -4084,6 +4136,7 @@
 ./packages/addon-kit/lib/tabs.js 1.9b2 aec1ebce533a99bbda9b5052e18346518702eb345b4f11a33636b03b312f78d7
 ./packages/addon-kit/lib/tabs.js 1.9b3 aec1ebce533a99bbda9b5052e18346518702eb345b4f11a33636b03b312f78d7
 ./packages/addon-kit/lib/tabs.js 1.9-dev aec1ebce533a99bbda9b5052e18346518702eb345b4f11a33636b03b312f78d7
+./packages/addon-kit/lib/tabs.js 1.9rc1 aec1ebce533a99bbda9b5052e18346518702eb345b4f11a33636b03b312f78d7
 ./packages/addon-kit/lib/timers.js 1.0 ce9b2b9cddd8785eeee41c588eabc984e49927748590e928adb19bac08af8a78
 ./packages/addon-kit/lib/timers.js 1.0rc1 ce9b2b9cddd8785eeee41c588eabc984e49927748590e928adb19bac08af8a78
 ./packages/addon-kit/lib/timers.js 1.0rc2 ce9b2b9cddd8785eeee41c588eabc984e49927748590e928adb19bac08af8a78
@@ -4156,6 +4209,7 @@
 ./packages/addon-kit/lib/timers.js 1.9b2 26bed37a039c6e1c4876048e5b5342c1569b9bee3daecb2cc904c93a26d94634
 ./packages/addon-kit/lib/timers.js 1.9b3 26bed37a039c6e1c4876048e5b5342c1569b9bee3daecb2cc904c93a26d94634
 ./packages/addon-kit/lib/timers.js 1.9-dev 26bed37a039c6e1c4876048e5b5342c1569b9bee3daecb2cc904c93a26d94634
+./packages/addon-kit/lib/timers.js 1.9rc1 26bed37a039c6e1c4876048e5b5342c1569b9bee3daecb2cc904c93a26d94634
 ./packages/addon-kit/lib/widget.js 0.9 37f3e2e01d9e76268e6d4b9384aec96ea40fc3ad22be9af62fe240b7e0045bf3
 ./packages/addon-kit/lib/widget.js 0.9rc1 37f3e2e01d9e76268e6d4b9384aec96ea40fc3ad22be9af62fe240b7e0045bf3
 ./packages/addon-kit/lib/widget.js 0.9rc2 37f3e2e01d9e76268e6d4b9384aec96ea40fc3ad22be9af62fe240b7e0045bf3
@@ -4250,6 +4304,7 @@
 ./packages/addon-kit/lib/widget.js 1.9b2 c189a1eb6d033aa215c998f6d5d40318f01d9afd87ae8b989200efa875feb3a8
 ./packages/addon-kit/lib/widget.js 1.9b3 c189a1eb6d033aa215c998f6d5d40318f01d9afd87ae8b989200efa875feb3a8
 ./packages/addon-kit/lib/widget.js 1.9-dev 38c4080326d449c181b98f39c799facbc5ee5e3186025b8e9258ac2c0971743a
+./packages/addon-kit/lib/widget.js 1.9rc1 c189a1eb6d033aa215c998f6d5d40318f01d9afd87ae8b989200efa875feb3a8
 ./packages/addon-kit/lib/windows.js 0.9 5568cde3585ad36df6f8843c1c2c833d82db002560b75ba6a1b4ce366bf88c51
 ./packages/addon-kit/lib/windows.js 0.9rc1 5568cde3585ad36df6f8843c1c2c833d82db002560b75ba6a1b4ce366bf88c51
 ./packages/addon-kit/lib/windows.js 0.9rc2 5568cde3585ad36df6f8843c1c2c833d82db002560b75ba6a1b4ce366bf88c51
@@ -4344,6 +4399,7 @@
 ./packages/addon-kit/lib/windows.js 1.9b2 37a106d4911bf5f2f6ac0ed595a19e00a7ecb32a9dca5726afccca413d647b17
 ./packages/addon-kit/lib/windows.js 1.9b3 37a106d4911bf5f2f6ac0ed595a19e00a7ecb32a9dca5726afccca413d647b17
 ./packages/addon-kit/lib/windows.js 1.9-dev 91881e6f7a72991fa9c9657f665c6bef5f37a465cbfb850ea15e07b8c7b312d4
+./packages/addon-kit/lib/windows.js 1.9rc1 37a106d4911bf5f2f6ac0ed595a19e00a7ecb32a9dca5726afccca413d647b17
 ./packages/addon-kit/tests/helpers.js 1.4.1 b16732d393c3cb494e63462ea2a72529a7c3fa63041a61e054e06e7328558f9c
 ./packages/addon-kit/tests/helpers.js 1.4.2 b16732d393c3cb494e63462ea2a72529a7c3fa63041a61e054e06e7328558f9c
 ./packages/addon-kit/tests/helpers.js 1.4.3 b16732d393c3cb494e63462ea2a72529a7c3fa63041a61e054e06e7328558f9c
@@ -4472,6 +4528,7 @@
 ./packages/addon-kit/tests/pagemod-test-helpers.js 1.9b2 b95dc7d7dd4930d3a9ad395c3d5253933d03a0c3c20fe3d31bdc88387c518af1
 ./packages/addon-kit/tests/pagemod-test-helpers.js 1.9b3 b95dc7d7dd4930d3a9ad395c3d5253933d03a0c3c20fe3d31bdc88387c518af1
 ./packages/addon-kit/tests/pagemod-test-helpers.js 1.9-dev b95dc7d7dd4930d3a9ad395c3d5253933d03a0c3c20fe3d31bdc88387c518af1
+./packages/addon-kit/tests/pagemod-test-helpers.js 1.9rc1 b95dc7d7dd4930d3a9ad395c3d5253933d03a0c3c20fe3d31bdc88387c518af1
 ./packages/addon-kit/tests/test-addon-page.js 1.10-dev 6ac72c7578e2653a76652d06ab12222fd807b994c6bafc70ee91815a24c64f69
 ./packages/addon-kit/tests/test-addon-page.js 1.6.1 c6ae61770c257830dcc42ea9efb4b1bafd4ecf4f105727363d76588661657b75
 ./packages/addon-kit/tests/test-addon-page.js 1.6.1rc1 c6ae61770c257830dcc42ea9efb4b1bafd4ecf4f105727363d76588661657b75
@@ -4500,6 +4557,7 @@
 ./packages/addon-kit/tests/test-addon-page.js 1.9b2 6ac72c7578e2653a76652d06ab12222fd807b994c6bafc70ee91815a24c64f69
 ./packages/addon-kit/tests/test-addon-page.js 1.9b3 6ac72c7578e2653a76652d06ab12222fd807b994c6bafc70ee91815a24c64f69
 ./packages/addon-kit/tests/test-addon-page.js 1.9-dev 2b352a0745e749c9e55d3d895ecb51db710c33d85f544059f7a8f85266a493d7
+./packages/addon-kit/tests/test-addon-page.js 1.9rc1 6ac72c7578e2653a76652d06ab12222fd807b994c6bafc70ee91815a24c64f69
 ./packages/addon-kit/tests/test-clipboard.js 0.9 42b7732a2da03e7fb4cbc1938b1d750b56d9824d038a435b9445cc005a11d3aa
 ./packages/addon-kit/tests/test-clipboard.js 0.9rc1 42b7732a2da03e7fb4cbc1938b1d750b56d9824d038a435b9445cc005a11d3aa
 ./packages/addon-kit/tests/test-clipboard.js 0.9rc2 42b7732a2da03e7fb4cbc1938b1d750b56d9824d038a435b9445cc005a11d3aa
@@ -4594,6 +4652,7 @@
 ./packages/addon-kit/tests/test-clipboard.js 1.9b2 930a1fb5cee37f58559c425b7eda1c7b865a0184e6c904a28cb1ebc1b7ec2294
 ./packages/addon-kit/tests/test-clipboard.js 1.9b3 930a1fb5cee37f58559c425b7eda1c7b865a0184e6c904a28cb1ebc1b7ec2294
 ./packages/addon-kit/tests/test-clipboard.js 1.9-dev 41252dcf9d7a333e5189aeabc96ce204b47d9a5bc8b0c3ed42d3ed36a90d74d4
+./packages/addon-kit/tests/test-clipboard.js 1.9rc1 930a1fb5cee37f58559c425b7eda1c7b865a0184e6c904a28cb1ebc1b7ec2294
 ./packages/addon-kit/tests/test-context-menu.html 0.9 fd72d3db201ecfc7145aa559226fbe78a7b6e66b1c4e66268147eaaae7685cd6
 ./packages/addon-kit/tests/test-context-menu.html 0.9rc1 fd72d3db201ecfc7145aa559226fbe78a7b6e66b1c4e66268147eaaae7685cd6
 ./packages/addon-kit/tests/test-context-menu.html 0.9rc2 fd72d3db201ecfc7145aa559226fbe78a7b6e66b1c4e66268147eaaae7685cd6
@@ -4688,6 +4747,7 @@
 ./packages/addon-kit/tests/test-context-menu.html 1.9b2 0cc602b1889d9966d4c90fcf4d976191659e6b8cc89e131fb2086da28ab9eb14
 ./packages/addon-kit/tests/test-context-menu.html 1.9b3 0cc602b1889d9966d4c90fcf4d976191659e6b8cc89e131fb2086da28ab9eb14
 ./packages/addon-kit/tests/test-context-menu.html 1.9-dev 1b12b3003b6d2eea6a17330e54105333fbe7d98ddd055fc2e87be8f6951fcfab
+./packages/addon-kit/tests/test-context-menu.html 1.9rc1 0cc602b1889d9966d4c90fcf4d976191659e6b8cc89e131fb2086da28ab9eb14
 ./packages/addon-kit/tests/test-context-menu.js 0.9 d0327262d1c42449a7711cb51d73e54d68b421e82ec7bb444ba705632b5dd1a4
 ./packages/addon-kit/tests/test-context-menu.js 0.9rc1 d0327262d1c42449a7711cb51d73e54d68b421e82ec7bb444ba705632b5dd1a4
 ./packages/addon-kit/tests/test-context-menu.js 0.9rc2 d0327262d1c42449a7711cb51d73e54d68b421e82ec7bb444ba705632b5dd1a4
@@ -4782,6 +4842,7 @@
 ./packages/addon-kit/tests/test-context-menu.js 1.9b2 950b2205626f962c9cb820c96517f7ade44d020d83e9f66dfa65d40ba6727212
 ./packages/addon-kit/tests/test-context-menu.js 1.9b3 5a1a1a0d571a8ceb5fc9e9ada9004fc3dbb40c7da6da8d96bbfc4443533677ef
 ./packages/addon-kit/tests/test-context-menu.js 1.9-dev 6fdedd076918625f5244355af6b9fb3073c2c1c494951ec0f68e18a4f9a9a737
+./packages/addon-kit/tests/test-context-menu.js 1.9rc1 5a1a1a0d571a8ceb5fc9e9ada9004fc3dbb40c7da6da8d96bbfc4443533677ef
 ./packages/addon-kit/tests/test-hotkeys.js 1.0 a8b57f0256fc91895456d09217bd12a16e890f9951e52703a50a91cd273d709c
 ./packages/addon-kit/tests/test-hotkeys.js 1.0b5 a8b57f0256fc91895456d09217bd12a16e890f9951e52703a50a91cd273d709c
 ./packages/addon-kit/tests/test-hotkeys.js 1.0b5rc1 a8b57f0256fc91895456d09217bd12a16e890f9951e52703a50a91cd273d709c
@@ -4857,6 +4918,7 @@
 ./packages/addon-kit/tests/test-hotkeys.js 1.9b2 119704d774e17019c11dafda8880a23c7b8c88bd240b79fdf5ac3b530b5e1594
 ./packages/addon-kit/tests/test-hotkeys.js 1.9b3 119704d774e17019c11dafda8880a23c7b8c88bd240b79fdf5ac3b530b5e1594
 ./packages/addon-kit/tests/test-hotkeys.js 1.9-dev b75be73856817bccbfaef0e6567311bd613d0e554eb260c649cfa84c475e77f2
+./packages/addon-kit/tests/test-hotkeys.js 1.9rc1 119704d774e17019c11dafda8880a23c7b8c88bd240b79fdf5ac3b530b5e1594
 ./packages/addon-kit/tests/test-l10n.js 1.10-dev a4ef4b5f54844c10bc2cc3d6904eed67efd72ceeba0870e97113a114e12723f6
 ./packages/addon-kit/tests/test-l10n.js 1.5 614c219f23614b7d624fc8e1bb33b7734454c11ff22625e8e18857e068bbe04e
 ./packages/addon-kit/tests/test-l10n.js 1.5b1 614c219f23614b7d624fc8e1bb33b7734454c11ff22625e8e18857e068bbe04e
@@ -4892,6 +4954,7 @@
 ./packages/addon-kit/tests/test-l10n.js 1.9b2 535feff2c8aa091f693b4982537770e3bf684a3c6f97bedd8886cd76a1988347
 ./packages/addon-kit/tests/test-l10n.js 1.9b3 535feff2c8aa091f693b4982537770e3bf684a3c6f97bedd8886cd76a1988347
 ./packages/addon-kit/tests/test-l10n.js 1.9-dev a4ef4b5f54844c10bc2cc3d6904eed67efd72ceeba0870e97113a114e12723f6
+./packages/addon-kit/tests/test-l10n.js 1.9rc1 535feff2c8aa091f693b4982537770e3bf684a3c6f97bedd8886cd76a1988347
 ./packages/addon-kit/tests/test-localization.js 0.9 a1d4afca35d123336f2e0302b60008fee936ac8f2058efb6d9605066c49ea7fe
 ./packages/addon-kit/tests/test-localization.js 0.9rc1 a1d4afca35d123336f2e0302b60008fee936ac8f2058efb6d9605066c49ea7fe
 ./packages/addon-kit/tests/test-localization.js 0.9rc2 a1d4afca35d123336f2e0302b60008fee936ac8f2058efb6d9605066c49ea7fe
@@ -4962,6 +5025,7 @@
 ./packages/addon-kit/tests/test-module.js 1.9b2 2ea0872015c8e568695fb24036be29f05e9fcc22040ca4f5797c3c0356ad0610
 ./packages/addon-kit/tests/test-module.js 1.9b3 2ea0872015c8e568695fb24036be29f05e9fcc22040ca4f5797c3c0356ad0610
 ./packages/addon-kit/tests/test-module.js 1.9-dev 2ea0872015c8e568695fb24036be29f05e9fcc22040ca4f5797c3c0356ad0610
+./packages/addon-kit/tests/test-module.js 1.9rc1 2ea0872015c8e568695fb24036be29f05e9fcc22040ca4f5797c3c0356ad0610
 ./packages/addon-kit/tests/test-notifications.js 0.9 35e72d86b64e213b4fc998fb8dd5d101d1fc430c2b229c0dab88b402cfc34ed2
 ./packages/addon-kit/tests/test-notifications.js 0.9rc1 35e72d86b64e213b4fc998fb8dd5d101d1fc430c2b229c0dab88b402cfc34ed2
 ./packages/addon-kit/tests/test-notifications.js 0.9rc2 35e72d86b64e213b4fc998fb8dd5d101d1fc430c2b229c0dab88b402cfc34ed2
@@ -5056,6 +5120,7 @@
 ./packages/addon-kit/tests/test-notifications.js 1.9b2 84bed34e5f5714bd89a6080a949c664019c1e1b7650f8f9f505de9d2efb7c390
 ./packages/addon-kit/tests/test-notifications.js 1.9b3 84bed34e5f5714bd89a6080a949c664019c1e1b7650f8f9f505de9d2efb7c390
 ./packages/addon-kit/tests/test-notifications.js 1.9-dev 84bed34e5f5714bd89a6080a949c664019c1e1b7650f8f9f505de9d2efb7c390
+./packages/addon-kit/tests/test-notifications.js 1.9rc1 84bed34e5f5714bd89a6080a949c664019c1e1b7650f8f9f505de9d2efb7c390
 ./packages/addon-kit/tests/test-page-mod.js 0.9 3e910552c113d7246be923267add86757a4c7efbe0fbf4830a9a0d3ed2db0e25
 ./packages/addon-kit/tests/test-page-mod.js 0.9rc1 3e910552c113d7246be923267add86757a4c7efbe0fbf4830a9a0d3ed2db0e25
 ./packages/addon-kit/tests/test-page-mod.js 0.9rc2 3e910552c113d7246be923267add86757a4c7efbe0fbf4830a9a0d3ed2db0e25
@@ -5150,6 +5215,7 @@
 ./packages/addon-kit/tests/test-page-mod.js 1.9b2 f6a8d190310f9fcedd354fd5e57423c4c4fb2a14f856eec6f719fd1c22f67c1a
 ./packages/addon-kit/tests/test-page-mod.js 1.9b3 f6a8d190310f9fcedd354fd5e57423c4c4fb2a14f856eec6f719fd1c22f67c1a
 ./packages/addon-kit/tests/test-page-mod.js 1.9-dev f46cd89e30a4b32c41c7e49123faa9d86f10478067c9c8259e1cbbc9a9c61bdf
+./packages/addon-kit/tests/test-page-mod.js 1.9rc1 f6a8d190310f9fcedd354fd5e57423c4c4fb2a14f856eec6f719fd1c22f67c1a
 ./packages/addon-kit/tests/test-page-worker.js 0.9 5c5ac2459a935d99b2ba63d4a75821e1c241ba38fd4abe1aaaf6ccd905f72a03
 ./packages/addon-kit/tests/test-page-worker.js 0.9rc1 5c5ac2459a935d99b2ba63d4a75821e1c241ba38fd4abe1aaaf6ccd905f72a03
 ./packages/addon-kit/tests/test-page-worker.js 0.9rc2 5c5ac2459a935d99b2ba63d4a75821e1c241ba38fd4abe1aaaf6ccd905f72a03
@@ -5244,6 +5310,7 @@
 ./packages/addon-kit/tests/test-page-worker.js 1.9b2 9b525fc5cf6ab3c67c9b464c9f85c3331c50db3446de2e5c5f19bcc51eeaebfc
 ./packages/addon-kit/tests/test-page-worker.js 1.9b3 9b525fc5cf6ab3c67c9b464c9f85c3331c50db3446de2e5c5f19bcc51eeaebfc
 ./packages/addon-kit/tests/test-page-worker.js 1.9-dev c589bb999c88fa8eb4b17ff3feb2f3b8da45a3ffaff1696231bf3e8be6f52dd7
+./packages/addon-kit/tests/test-page-worker.js 1.9rc1 9b525fc5cf6ab3c67c9b464c9f85c3331c50db3446de2e5c5f19bcc51eeaebfc
 ./packages/addon-kit/tests/test-panel.js 0.9 384879cb73173b743f0ddeadb78161a300815967d7d8c002f6ec24151f395a49
 ./packages/addon-kit/tests/test-panel.js 0.9rc1 313d98372d3e8523a871ba6631a92cc58b088976b4e043602bd29e44657163ae
 ./packages/addon-kit/tests/test-panel.js 0.9rc2 384879cb73173b743f0ddeadb78161a300815967d7d8c002f6ec24151f395a49
@@ -5338,6 +5405,7 @@
 ./packages/addon-kit/tests/test-panel.js 1.9b2 3b25644c0c71ac0cf33b13c3b0d6e878947c94e9f97403b62fd88ba14cf1360d
 ./packages/addon-kit/tests/test-panel.js 1.9b3 3b25644c0c71ac0cf33b13c3b0d6e878947c94e9f97403b62fd88ba14cf1360d
 ./packages/addon-kit/tests/test-panel.js 1.9-dev ed6119a19f161c3d011f584b2bf73e21995cc805b307726bcb54108c5c9764db
+./packages/addon-kit/tests/test-panel.js 1.9rc1 3b25644c0c71ac0cf33b13c3b0d6e878947c94e9f97403b62fd88ba14cf1360d
 ./packages/addon-kit/tests/test-passwords.js 1.0 26f832cd73045f459ab11902014da50fa8885567e3135afeb9e1cf1267421e60
 ./packages/addon-kit/tests/test-passwords.js 1.0b4.1 71375299e2b14dee494ead4870dfb46dd929236b9f75747e55af5aa5a80e54ad
 ./packages/addon-kit/tests/test-passwords.js 1.0b4 71375299e2b14dee494ead4870dfb46dd929236b9f75747e55af5aa5a80e54ad
@@ -5418,6 +5486,7 @@
 ./packages/addon-kit/tests/test-passwords.js 1.9b2 d2b60bdb4a31e15ca27913f07df6f5f7d8a38ac37790c45384c7ad9351e08981
 ./packages/addon-kit/tests/test-passwords.js 1.9b3 d2b60bdb4a31e15ca27913f07df6f5f7d8a38ac37790c45384c7ad9351e08981
 ./packages/addon-kit/tests/test-passwords.js 1.9-dev d2b60bdb4a31e15ca27913f07df6f5f7d8a38ac37790c45384c7ad9351e08981
+./packages/addon-kit/tests/test-passwords.js 1.9rc1 d2b60bdb4a31e15ca27913f07df6f5f7d8a38ac37790c45384c7ad9351e08981
 ./packages/addon-kit/tests/test-private-browsing.js 0.9 2303916e8aea92b8fa4e3e4a98d1ac3952be2d8bcf1a652a0734bdf90cc37ba7
 ./packages/addon-kit/tests/test-private-browsing.js 0.9rc1 2303916e8aea92b8fa4e3e4a98d1ac3952be2d8bcf1a652a0734bdf90cc37ba7
 ./packages/addon-kit/tests/test-private-browsing.js 0.9rc2 2303916e8aea92b8fa4e3e4a98d1ac3952be2d8bcf1a652a0734bdf90cc37ba7
@@ -5512,6 +5581,7 @@
 ./packages/addon-kit/tests/test-private-browsing.js 1.9b2 81f7b0044c955e38e6407e0b700c9f91669bde6943212a109fc03532fe4b3f2e
 ./packages/addon-kit/tests/test-private-browsing.js 1.9b3 81f7b0044c955e38e6407e0b700c9f91669bde6943212a109fc03532fe4b3f2e
 ./packages/addon-kit/tests/test-private-browsing.js 1.9-dev fff38eaa21897bca2efd6fa31487947433c1b4ae151c9d73433ee027cd0e3090
+./packages/addon-kit/tests/test-private-browsing.js 1.9rc1 81f7b0044c955e38e6407e0b700c9f91669bde6943212a109fc03532fe4b3f2e
 ./packages/addon-kit/tests/test-request.js 0.9 673d5e8586b02bebfc33be3ae909987b873f731269a30ea9fbcc9c0225c170e5
 ./packages/addon-kit/tests/test-request.js 0.9rc1 673d5e8586b02bebfc33be3ae909987b873f731269a30ea9fbcc9c0225c170e5
 ./packages/addon-kit/tests/test-request.js 0.9rc2 673d5e8586b02bebfc33be3ae909987b873f731269a30ea9fbcc9c0225c170e5
@@ -5606,6 +5676,7 @@
 ./packages/addon-kit/tests/test-request.js 1.9b2 522b9f4b15a169ebf3d41f05c163d50fea1e0edc778852ad8157d1db45de0028
 ./packages/addon-kit/tests/test-request.js 1.9b3 522b9f4b15a169ebf3d41f05c163d50fea1e0edc778852ad8157d1db45de0028
 ./packages/addon-kit/tests/test-request.js 1.9-dev 14ac55feb60a32225866df41b2e6aff7b844a006a2054f201f537dc909874ae9
+./packages/addon-kit/tests/test-request.js 1.9rc1 522b9f4b15a169ebf3d41f05c163d50fea1e0edc778852ad8157d1db45de0028
 ./packages/addon-kit/tests/test-selection.js 0.9 0410ecb05b0a55d7a835e861bf7010458a6c2163f1a24486f577e03f8b12e4ab
 ./packages/addon-kit/tests/test-selection.js 0.9rc1 0410ecb05b0a55d7a835e861bf7010458a6c2163f1a24486f577e03f8b12e4ab
 ./packages/addon-kit/tests/test-selection.js 0.9rc2 0410ecb05b0a55d7a835e861bf7010458a6c2163f1a24486f577e03f8b12e4ab
@@ -5700,6 +5771,7 @@
 ./packages/addon-kit/tests/test-selection.js 1.9b2 8140b635bd9e5205a83c62c5ee402cf9c77862db36618b95dfd7e79a9001810f
 ./packages/addon-kit/tests/test-selection.js 1.9b3 9b3917ba7017fbf901781809b8f263adce755263ebac9e1f2282c8190247ef5a
 ./packages/addon-kit/tests/test-selection.js 1.9-dev fa0a8cc05964850557063ad515719e8f3509999058404eeb5b8f502e98744424
+./packages/addon-kit/tests/test-selection.js 1.9rc1 9b3917ba7017fbf901781809b8f263adce755263ebac9e1f2282c8190247ef5a
 ./packages/addon-kit/tests/test-simple-prefs.js 1.10-dev 252cba0655fa377a1cec8b1ae4f974018360e94301c9cb587f76df7428c06982
 ./packages/addon-kit/tests/test-simple-prefs.js 1.4.1 1a8b5feb6834743269cb176fa13eeb93bd9a0c86c87f3b5031b99772e40205b8
 ./packages/addon-kit/tests/test-simple-prefs.js 1.4 1a8b5feb6834743269cb176fa13eeb93bd9a0c86c87f3b5031b99772e40205b8
@@ -5748,6 +5820,7 @@
 ./packages/addon-kit/tests/test-simple-prefs.js 1.9b2 252cba0655fa377a1cec8b1ae4f974018360e94301c9cb587f76df7428c06982
 ./packages/addon-kit/tests/test-simple-prefs.js 1.9b3 252cba0655fa377a1cec8b1ae4f974018360e94301c9cb587f76df7428c06982
 ./packages/addon-kit/tests/test-simple-prefs.js 1.9-dev 2b3bdc3a25cb679a2c31736d2b7b1c9ced7ce39148a073e6eba371b6c62a19e4
+./packages/addon-kit/tests/test-simple-prefs.js 1.9rc1 252cba0655fa377a1cec8b1ae4f974018360e94301c9cb587f76df7428c06982
 ./packages/addon-kit/tests/test-simple-storage.js 0.9 881794f545c9b33f4fe3df81db711e23fb8da9484a9a6666d58ffb4de0982cb1
 ./packages/addon-kit/tests/test-simple-storage.js 0.9rc1 881794f545c9b33f4fe3df81db711e23fb8da9484a9a6666d58ffb4de0982cb1
 ./packages/addon-kit/tests/test-simple-storage.js 0.9rc2 881794f545c9b33f4fe3df81db711e23fb8da9484a9a6666d58ffb4de0982cb1
@@ -5842,6 +5915,7 @@
 ./packages/addon-kit/tests/test-simple-storage.js 1.9b2 8c1b3b99c2cee7164cbc7fce0b55ba5593438031a8e0341b1ba9cb86c728f610
 ./packages/addon-kit/tests/test-simple-storage.js 1.9b3 8c1b3b99c2cee7164cbc7fce0b55ba5593438031a8e0341b1ba9cb86c728f610
 ./packages/addon-kit/tests/test-simple-storage.js 1.9-dev 493f2ec3f67bdfbefc603b6c73aa0ffd55d0ac437a69a52e291f045163b0d152
+./packages/addon-kit/tests/test-simple-storage.js 1.9rc1 8c1b3b99c2cee7164cbc7fce0b55ba5593438031a8e0341b1ba9cb86c728f610
 ./packages/addon-kit/tests/test-tabs.js 0.9 50fd5d90b09b196700a77ced749f9e3d6f73a81e5f43298a1bd3731705209fac
 ./packages/addon-kit/tests/test-tabs.js 0.9rc1 50fd5d90b09b196700a77ced749f9e3d6f73a81e5f43298a1bd3731705209fac
 ./packages/addon-kit/tests/test-tabs.js 0.9rc2 50fd5d90b09b196700a77ced749f9e3d6f73a81e5f43298a1bd3731705209fac
@@ -5936,6 +6010,7 @@
 ./packages/addon-kit/tests/test-tabs.js 1.9b2 ef4b965f55c7ccbbfe2b7923acb6daeb55b9dc357bb5d260a9eae752794db0ab
 ./packages/addon-kit/tests/test-tabs.js 1.9b3 ef4b965f55c7ccbbfe2b7923acb6daeb55b9dc357bb5d260a9eae752794db0ab
 ./packages/addon-kit/tests/test-tabs.js 1.9-dev 7784fe051f37ded5acb7a7262f73d9ecbf3a6870f712e092bd97df13d99f837b
+./packages/addon-kit/tests/test-tabs.js 1.9rc1 ef4b965f55c7ccbbfe2b7923acb6daeb55b9dc357bb5d260a9eae752794db0ab
 ./packages/addon-kit/tests/test-timers.js 1.10-dev e28d267156e659059560ce155681954e16fbcd48b372787003b17478b2503116
 ./packages/addon-kit/tests/test-timers.js 1.1 47694e1a7db7825a4b6efa8422515c5212b63c7d94ef28bf2b0be509aaf85af8
 ./packages/addon-kit/tests/test-timers.js 1.1rc1 47694e1a7db7825a4b6efa8422515c5212b63c7d94ef28bf2b0be509aaf85af8
@@ -5999,6 +6074,7 @@
 ./packages/addon-kit/tests/test-timers.js 1.9b2 e28d267156e659059560ce155681954e16fbcd48b372787003b17478b2503116
 ./packages/addon-kit/tests/test-timers.js 1.9b3 e28d267156e659059560ce155681954e16fbcd48b372787003b17478b2503116
 ./packages/addon-kit/tests/test-timers.js 1.9-dev e28d267156e659059560ce155681954e16fbcd48b372787003b17478b2503116
+./packages/addon-kit/tests/test-timers.js 1.9rc1 e28d267156e659059560ce155681954e16fbcd48b372787003b17478b2503116
 ./packages/addon-kit/tests/test-widget.js 0.9 0bd241c7239358b48a4acd8bbcce77ed3b09662d4f6e15d50f46dcb62749b1a7
 ./packages/addon-kit/tests/test-widget.js 0.9rc1 0bd241c7239358b48a4acd8bbcce77ed3b09662d4f6e15d50f46dcb62749b1a7
 ./packages/addon-kit/tests/test-widget.js 0.9rc2 0bd241c7239358b48a4acd8bbcce77ed3b09662d4f6e15d50f46dcb62749b1a7
@@ -6093,6 +6169,7 @@
 ./packages/addon-kit/tests/test-widget.js 1.9b2 2ba675008346127b7241128940ee0330838c4949aa1418d4bcccea185b3e56f5
 ./packages/addon-kit/tests/test-widget.js 1.9b3 2ba675008346127b7241128940ee0330838c4949aa1418d4bcccea185b3e56f5
 ./packages/addon-kit/tests/test-widget.js 1.9-dev 8b861ae9a6cf2cbc2c4548c2860b8b5d05c28ff72561afe4a2ff75575bc9a576
+./packages/addon-kit/tests/test-widget.js 1.9rc1 2ba675008346127b7241128940ee0330838c4949aa1418d4bcccea185b3e56f5
 ./packages/addon-kit/tests/test-windows.js 0.9 b5e288054aa2b3415d5a3cad8edf34b3d2e26f443bdd52ee925901a6882f6429
 ./packages/addon-kit/tests/test-windows.js 0.9rc1 b5e288054aa2b3415d5a3cad8edf34b3d2e26f443bdd52ee925901a6882f6429
 ./packages/addon-kit/tests/test-windows.js 0.9rc2 b5e288054aa2b3415d5a3cad8edf34b3d2e26f443bdd52ee925901a6882f6429
@@ -6187,6 +6264,7 @@
 ./packages/addon-kit/tests/test-windows.js 1.9b2 0a03391252d9dfa5e255142ffbc6053a8faa6141a5af961267df6cfc72b834fd
 ./packages/addon-kit/tests/test-windows.js 1.9b3 0a03391252d9dfa5e255142ffbc6053a8faa6141a5af961267df6cfc72b834fd
 ./packages/addon-kit/tests/test-windows.js 1.9-dev 123d9928c305f176fa696e4276893c1f8ba70d164de1b8f600522d0d10d852a9
+./packages/addon-kit/tests/test-windows.js 1.9rc1 0a03391252d9dfa5e255142ffbc6053a8faa6141a5af961267df6cfc72b834fd
 ./packages/api-utils/data/bootstrap-remote-process.js 1.0 05b0eff7f27bf97b7cbc5abbc4659deec6aa57624625f8f59e693fc0051d6615
 ./packages/api-utils/data/bootstrap-remote-process.js 1.0b1 66c646f17265927cd47e3d65c44515665272e06b2b332f5e2c877f38d6c44edd
 ./packages/api-utils/data/bootstrap-remote-process.js 1.0b1rc1 66c646f17265927cd47e3d65c44515665272e06b2b332f5e2c877f38d6c44edd
@@ -6355,6 +6433,7 @@
 ./packages/api-utils/data/test-content-symbiont.js 1.9b2 76963df111826b5d34135c071a9eb568c5f79af5eba8cdeb9287388b7241f1dc
 ./packages/api-utils/data/test-content-symbiont.js 1.9b3 76963df111826b5d34135c071a9eb568c5f79af5eba8cdeb9287388b7241f1dc
 ./packages/api-utils/data/test-content-symbiont.js 1.9-dev 76963df111826b5d34135c071a9eb568c5f79af5eba8cdeb9287388b7241f1dc
+./packages/api-utils/data/test-content-symbiont.js 1.9rc1 76963df111826b5d34135c071a9eb568c5f79af5eba8cdeb9287388b7241f1dc
 ./packages/api-utils/data/test-message-manager.js 1.10-dev 54059f9fc9a545d5164007daa2018f8ff6e87b3d823a629b46b5139c5db4ce3d
 ./packages/api-utils/data/test-message-manager.js 1.5 54059f9fc9a545d5164007daa2018f8ff6e87b3d823a629b46b5139c5db4ce3d
 ./packages/api-utils/data/test-message-manager.js 1.5b1 54059f9fc9a545d5164007daa2018f8ff6e87b3d823a629b46b5139c5db4ce3d
@@ -6390,6 +6469,7 @@
 ./packages/api-utils/data/test-message-manager.js 1.9b2 54059f9fc9a545d5164007daa2018f8ff6e87b3d823a629b46b5139c5db4ce3d
 ./packages/api-utils/data/test-message-manager.js 1.9b3 54059f9fc9a545d5164007daa2018f8ff6e87b3d823a629b46b5139c5db4ce3d
 ./packages/api-utils/data/test-message-manager.js 1.9-dev 54059f9fc9a545d5164007daa2018f8ff6e87b3d823a629b46b5139c5db4ce3d
+./packages/api-utils/data/test-message-manager.js 1.9rc1 54059f9fc9a545d5164007daa2018f8ff6e87b3d823a629b46b5139c5db4ce3d
 ./packages/api-utils/data/test-trusted-document.html 1.10-dev 4b05030eade940cac53d9be6aa1d97c7aaa592bbe2610aaa39b162bf76957ab6
 ./packages/api-utils/data/test-trusted-document.html 1.4.1 b9a1bb2ea01a0a2fbf5f2e349e8361a73db529ecade2e7dd0c5295fbfde4567d
 ./packages/api-utils/data/test-trusted-document.html 1.4.2 b9a1bb2ea01a0a2fbf5f2e349e8361a73db529ecade2e7dd0c5295fbfde4567d
@@ -6438,6 +6518,7 @@
 ./packages/api-utils/data/test-trusted-document.html 1.9b2 4b05030eade940cac53d9be6aa1d97c7aaa592bbe2610aaa39b162bf76957ab6
 ./packages/api-utils/data/test-trusted-document.html 1.9b3 4b05030eade940cac53d9be6aa1d97c7aaa592bbe2610aaa39b162bf76957ab6
 ./packages/api-utils/data/test-trusted-document.html 1.9-dev 0c03768c532eaeb7f9e0f453301e80fa0a7abdd58e20869cfe3cad249bb0b091
+./packages/api-utils/data/test-trusted-document.html 1.9rc1 4b05030eade940cac53d9be6aa1d97c7aaa592bbe2610aaa39b162bf76957ab6
 ./packages/api-utils/data/worker.js 1.6.1 cc93359783b4ce73a370e8f19d108c854dba9afa3adf15b2da27230da13c80e6
 ./packages/api-utils/data/worker.js 1.6.1rc1 cc93359783b4ce73a370e8f19d108c854dba9afa3adf15b2da27230da13c80e6
 ./packages/api-utils/data/worker.js 1.6b1 cc93359783b4ce73a370e8f19d108c854dba9afa3adf15b2da27230da13c80e6
@@ -6466,6 +6547,7 @@
 ./packages/api-utils/lib/addon/installer.js 1.9b2 2a18f3828a323fdb441ff6536200aa46d47dda14c9cb93e0503697de7fe4cf8b
 ./packages/api-utils/lib/addon/installer.js 1.9b3 2a18f3828a323fdb441ff6536200aa46d47dda14c9cb93e0503697de7fe4cf8b
 ./packages/api-utils/lib/addon/installer.js 1.9-dev 2a18f3828a323fdb441ff6536200aa46d47dda14c9cb93e0503697de7fe4cf8b
+./packages/api-utils/lib/addon/installer.js 1.9rc1 2a18f3828a323fdb441ff6536200aa46d47dda14c9cb93e0503697de7fe4cf8b
 ./packages/api-utils/lib/addon/runner.js 1.10-dev 028cefe30a657425f6b8c123248fcfb33d2e6b72778c6a83eb31603971b6fc96
 ./packages/api-utils/lib/addon/runner.js 1.8.1 c3c2a31e9e483e19596ce7ca4702ac4622f6c2723e020a8e7f7acaf859af013d
 ./packages/api-utils/lib/addon/runner.js 1.8.2 c3c2a31e9e483e19596ce7ca4702ac4622f6c2723e020a8e7f7acaf859af013d
@@ -6480,6 +6562,7 @@
 ./packages/api-utils/lib/addon/runner.js 1.9b2 028cefe30a657425f6b8c123248fcfb33d2e6b72778c6a83eb31603971b6fc96
 ./packages/api-utils/lib/addon/runner.js 1.9b3 028cefe30a657425f6b8c123248fcfb33d2e6b72778c6a83eb31603971b6fc96
 ./packages/api-utils/lib/addon/runner.js 1.9-dev ab062221e0492c4e0e698665fdc65b776d075d241803948122e8866776d18deb
+./packages/api-utils/lib/addon/runner.js 1.9rc1 028cefe30a657425f6b8c123248fcfb33d2e6b72778c6a83eb31603971b6fc96
 ./packages/api-utils/lib/api-utils.js 1.0 a5afc1236d022272bd80a6b4b4dda55f606d4ddbd678cc245a95236642c32c77
 ./packages/api-utils/lib/api-utils.js 1.0b1 a5afc1236d022272bd80a6b4b4dda55f606d4ddbd678cc245a95236642c32c77
 ./packages/api-utils/lib/api-utils.js 1.0b1rc1 a5afc1236d022272bd80a6b4b4dda55f606d4ddbd678cc245a95236642c32c77
@@ -6571,6 +6654,7 @@
 ./packages/api-utils/lib/api-utils.js 1.9b2 18c9219edf012f4eb8a863139e640ea7a18817055d21a6086619d6aa08f2d887
 ./packages/api-utils/lib/api-utils.js 1.9b3 18c9219edf012f4eb8a863139e640ea7a18817055d21a6086619d6aa08f2d887
 ./packages/api-utils/lib/api-utils.js 1.9-dev 18c9219edf012f4eb8a863139e640ea7a18817055d21a6086619d6aa08f2d887
+./packages/api-utils/lib/api-utils.js 1.9rc1 18c9219edf012f4eb8a863139e640ea7a18817055d21a6086619d6aa08f2d887
 ./packages/api-utils/lib/app-strings.js 1.0 af30f57b0b38cc2cb32be69137d0a2d39fba0739222e2af43150fe756fcd537d
 ./packages/api-utils/lib/app-strings.js 1.0b1 af30f57b0b38cc2cb32be69137d0a2d39fba0739222e2af43150fe756fcd537d
 ./packages/api-utils/lib/app-strings.js 1.0b1rc1 af30f57b0b38cc2cb32be69137d0a2d39fba0739222e2af43150fe756fcd537d
@@ -6662,6 +6746,7 @@
 ./packages/api-utils/lib/app-strings.js 1.9b2 d8d0c1243097b8176b151a51de832475347ddeed918e0ee047189373a9f5314d
 ./packages/api-utils/lib/app-strings.js 1.9b3 d8d0c1243097b8176b151a51de832475347ddeed918e0ee047189373a9f5314d
 ./packages/api-utils/lib/app-strings.js 1.9-dev d8d0c1243097b8176b151a51de832475347ddeed918e0ee047189373a9f5314d
+./packages/api-utils/lib/app-strings.js 1.9rc1 d8d0c1243097b8176b151a51de832475347ddeed918e0ee047189373a9f5314d
 ./packages/api-utils/lib/array.js 1.0 78cae018f9ff79c9d20913ea4cf4f1fd5f87aa2d7e7287725886df4691d59014
 ./packages/api-utils/lib/array.js 1.0b5 78cae018f9ff79c9d20913ea4cf4f1fd5f87aa2d7e7287725886df4691d59014
 ./packages/api-utils/lib/array.js 1.0b5rc1 78cae018f9ff79c9d20913ea4cf4f1fd5f87aa2d7e7287725886df4691d59014
@@ -6737,10 +6822,12 @@
 ./packages/api-utils/lib/array.js 1.9b2 df62fa1a9b3d804d3bebcdcf970bcfffa4387d4a52f03b6ad234c721ff5791c7
 ./packages/api-utils/lib/array.js 1.9b3 df62fa1a9b3d804d3bebcdcf970bcfffa4387d4a52f03b6ad234c721ff5791c7
 ./packages/api-utils/lib/array.js 1.9-dev df62fa1a9b3d804d3bebcdcf970bcfffa4387d4a52f03b6ad234c721ff5791c7
+./packages/api-utils/lib/array.js 1.9rc1 df62fa1a9b3d804d3bebcdcf970bcfffa4387d4a52f03b6ad234c721ff5791c7
 ./packages/api-utils/lib/base64.js 1.10-dev 43b63fc0aa3c6b884d1018410f5a3afee47cb220a70f0ce1c45ee154c44d0483
 ./packages/api-utils/lib/base64.js 1.9b1 43b63fc0aa3c6b884d1018410f5a3afee47cb220a70f0ce1c45ee154c44d0483
 ./packages/api-utils/lib/base64.js 1.9b2 43b63fc0aa3c6b884d1018410f5a3afee47cb220a70f0ce1c45ee154c44d0483
 ./packages/api-utils/lib/base64.js 1.9b3 43b63fc0aa3c6b884d1018410f5a3afee47cb220a70f0ce1c45ee154c44d0483
+./packages/api-utils/lib/base64.js 1.9rc1 43b63fc0aa3c6b884d1018410f5a3afee47cb220a70f0ce1c45ee154c44d0483
 ./packages/api-utils/lib/base.js 1.5 59a13dee35dcb90d0805aaa895028f02b793448747637f02ecd75736131a6258
 ./packages/api-utils/lib/base.js 1.5b1 59a13dee35dcb90d0805aaa895028f02b793448747637f02ecd75736131a6258
 ./packages/api-utils/lib/base.js 1.5b2 59a13dee35dcb90d0805aaa895028f02b793448747637f02ecd75736131a6258
@@ -6853,6 +6940,7 @@
 ./packages/api-utils/lib/byte-streams.js 1.9b2 70fb9a7ec33b9dda9b70e0d5c6b0234362e30c35f269027269b54a1d6f130eea
 ./packages/api-utils/lib/byte-streams.js 1.9b3 70fb9a7ec33b9dda9b70e0d5c6b0234362e30c35f269027269b54a1d6f130eea
 ./packages/api-utils/lib/byte-streams.js 1.9-dev 70fb9a7ec33b9dda9b70e0d5c6b0234362e30c35f269027269b54a1d6f130eea
+./packages/api-utils/lib/byte-streams.js 1.9rc1 70fb9a7ec33b9dda9b70e0d5c6b0234362e30c35f269027269b54a1d6f130eea
 ./packages/api-utils/lib/channel.js 1.4.1 c0c8403f373171c042b1995667f2446b6d96ff1650aef881092f97ce981be4c2
 ./packages/api-utils/lib/channel.js 1.4.2 c0c8403f373171c042b1995667f2446b6d96ff1650aef881092f97ce981be4c2
 ./packages/api-utils/lib/channel.js 1.4.3b1 c0c8403f373171c042b1995667f2446b6d96ff1650aef881092f97ce981be4c2
@@ -6978,6 +7066,7 @@
 ./packages/api-utils/lib/collection.js 1.9b2 dd21613fd2a748fcee0510f2ce774248c03c3fa34459c5a238d9ffd9b5d1f110
 ./packages/api-utils/lib/collection.js 1.9b3 dd21613fd2a748fcee0510f2ce774248c03c3fa34459c5a238d9ffd9b5d1f110
 ./packages/api-utils/lib/collection.js 1.9-dev dd21613fd2a748fcee0510f2ce774248c03c3fa34459c5a238d9ffd9b5d1f110
+./packages/api-utils/lib/collection.js 1.9rc1 dd21613fd2a748fcee0510f2ce774248c03c3fa34459c5a238d9ffd9b5d1f110
 ./packages/api-utils/lib/content/content-proxy.js 1.0 f59ad2e83c61b8d3012a4e9843b6d46f62754ac9005b6344a0a375a6766e54e3
 ./packages/api-utils/lib/content/content-proxy.js 1.0rc1 1a72c4f737d25b0dbe4d7dbb988d1888664588d2c0726c8e50eb5611d985a384
 ./packages/api-utils/lib/content/content-proxy.js 1.0rc2 f59ad2e83c61b8d3012a4e9843b6d46f62754ac9005b6344a0a375a6766e54e3
@@ -7016,6 +7105,7 @@
 ./packages/api-utils/lib/content/content-proxy.js 1.9b2 b55051a55e39aeb2196fd30f242bf4f4cffd286b8fc6332d391a33b1c502a623
 ./packages/api-utils/lib/content/content-proxy.js 1.9b3 b44e6da9c6e853aac8584b5e72cb3df43388e8c08992a30cb19e8bdbd10bca60
 ./packages/api-utils/lib/content/content-proxy.js 1.9-dev b55051a55e39aeb2196fd30f242bf4f4cffd286b8fc6332d391a33b1c502a623
+./packages/api-utils/lib/content/content-proxy.js 1.9rc1 b44e6da9c6e853aac8584b5e72cb3df43388e8c08992a30cb19e8bdbd10bca60
 ./packages/api-utils/lib/content/content-worker.js 1.10-dev 42aa78f8198b8ac9c613827ce66b6bedc4d769b304a662f991bf6fd541d5f3cb
 ./packages/api-utils/lib/content/content-worker.js 1.8.1 42aa78f8198b8ac9c613827ce66b6bedc4d769b304a662f991bf6fd541d5f3cb
 ./packages/api-utils/lib/content/content-worker.js 1.8.2 42aa78f8198b8ac9c613827ce66b6bedc4d769b304a662f991bf6fd541d5f3cb
@@ -7030,6 +7120,7 @@
 ./packages/api-utils/lib/content/content-worker.js 1.9b2 42aa78f8198b8ac9c613827ce66b6bedc4d769b304a662f991bf6fd541d5f3cb
 ./packages/api-utils/lib/content/content-worker.js 1.9b3 42aa78f8198b8ac9c613827ce66b6bedc4d769b304a662f991bf6fd541d5f3cb
 ./packages/api-utils/lib/content/content-worker.js 1.9-dev 42aa78f8198b8ac9c613827ce66b6bedc4d769b304a662f991bf6fd541d5f3cb
+./packages/api-utils/lib/content/content-worker.js 1.9rc1 42aa78f8198b8ac9c613827ce66b6bedc4d769b304a662f991bf6fd541d5f3cb
 ./packages/api-utils/lib/content.js 1.0 9e250d23b61f987920af698c10be725aafefc741caa0120311018223cbd99f95
 ./packages/api-utils/lib/content.js 1.0b1 9e250d23b61f987920af698c10be725aafefc741caa0120311018223cbd99f95
 ./packages/api-utils/lib/content.js 1.0b1rc1 9e250d23b61f987920af698c10be725aafefc741caa0120311018223cbd99f95
@@ -7121,6 +7212,7 @@
 ./packages/api-utils/lib/content.js 1.9b2 0119f8c1c84d40bd8faa413aa9ce3106c86ba5c996f231f98753bff84fdb1db3
 ./packages/api-utils/lib/content.js 1.9b3 0119f8c1c84d40bd8faa413aa9ce3106c86ba5c996f231f98753bff84fdb1db3
 ./packages/api-utils/lib/content.js 1.9-dev 0119f8c1c84d40bd8faa413aa9ce3106c86ba5c996f231f98753bff84fdb1db3
+./packages/api-utils/lib/content.js 1.9rc1 0119f8c1c84d40bd8faa413aa9ce3106c86ba5c996f231f98753bff84fdb1db3
 ./packages/api-utils/lib/content/loader.js 1.0 9569fc805de52ffcdfe4bb32bf49fc56fbdd56059b129d1dda682a8b16493599
 ./packages/api-utils/lib/content/loader.js 1.0b1 4587833e017b469ecec61dc339ff14839e739dd509ae4fb7c4a1d5f52d29d66f
 ./packages/api-utils/lib/content/loader.js 1.0b1rc1 997e1cceb3d0c64a4171443451064b73323330191d963cd611dd0c580a597e7c
@@ -7212,6 +7304,7 @@
 ./packages/api-utils/lib/content/loader.js 1.9b2 1fcb21d3e23b8d38d1054dcfa4c7a99d3f1dc77da41fc5a222dd38fb723c2f9e
 ./packages/api-utils/lib/content/loader.js 1.9b3 1fcb21d3e23b8d38d1054dcfa4c7a99d3f1dc77da41fc5a222dd38fb723c2f9e
 ./packages/api-utils/lib/content/loader.js 1.9-dev 1fcb21d3e23b8d38d1054dcfa4c7a99d3f1dc77da41fc5a222dd38fb723c2f9e
+./packages/api-utils/lib/content/loader.js 1.9rc1 1fcb21d3e23b8d38d1054dcfa4c7a99d3f1dc77da41fc5a222dd38fb723c2f9e
 ./packages/api-utils/lib/content/symbiont.js 1.0b1 127ebfc923f9327e8f350f69758dbc21ef69047f63387018f6acd432a57446b8
 ./packages/api-utils/lib/content/symbiont.js 1.0b1rc1 127ebfc923f9327e8f350f69758dbc21ef69047f63387018f6acd432a57446b8
 ./packages/api-utils/lib/content/symbiont.js 1.0b1rc2 127ebfc923f9327e8f350f69758dbc21ef69047f63387018f6acd432a57446b8
@@ -7303,6 +7396,7 @@
 ./packages/api-utils/lib/content/symbiont.js 1.9b2 3cbcee3e4ae89b2d5fba7e50567b30559e040c10f37d1aee6d0d3c44d703b662
 ./packages/api-utils/lib/content/symbiont.js 1.9b3 3cbcee3e4ae89b2d5fba7e50567b30559e040c10f37d1aee6d0d3c44d703b662
 ./packages/api-utils/lib/content/symbiont.js 1.9-dev 32a2b2decb56b45ad63e3ccee3c30bd23373d66adb36698e4974abf776d4ca1d
+./packages/api-utils/lib/content/symbiont.js 1.9rc1 3cbcee3e4ae89b2d5fba7e50567b30559e040c10f37d1aee6d0d3c44d703b662
 ./packages/api-utils/lib/content/worker.js 1.0b1 2d55a0cc63c6edb1d848b75137f7e5ad7ee4ea417209b8e91a77cdf01d0ab2e3
 ./packages/api-utils/lib/content/worker.js 1.0b1rc1 2d55a0cc63c6edb1d848b75137f7e5ad7ee4ea417209b8e91a77cdf01d0ab2e3
 ./packages/api-utils/lib/content/worker.js 1.0b1rc2 2d55a0cc63c6edb1d848b75137f7e5ad7ee4ea417209b8e91a77cdf01d0ab2e3
@@ -7394,6 +7488,7 @@
 ./packages/api-utils/lib/content/worker.js 1.9b2 a3b5cd3f439d63b881a4d88891bd89b92770a1f57d0106a8dee2066b932f8748
 ./packages/api-utils/lib/content/worker.js 1.9b3 a3b5cd3f439d63b881a4d88891bd89b92770a1f57d0106a8dee2066b932f8748
 ./packages/api-utils/lib/content/worker.js 1.9-dev 60a3d51950582b63612f7aefd758af4f2852cc93a1cb647e4238971786ee8cac
+./packages/api-utils/lib/content/worker.js 1.9rc1 a3b5cd3f439d63b881a4d88891bd89b92770a1f57d0106a8dee2066b932f8748
 ./packages/api-utils/lib/cortex.js 1.0b3 c0f1cd0975149d431c45b674ff88119d8c69d265cf7c9ffe6e8e7076397b27c5
 ./packages/api-utils/lib/cortex.js 1.0b3rc1 c0f1cd0975149d431c45b674ff88119d8c69d265cf7c9ffe6e8e7076397b27c5
 ./packages/api-utils/lib/cortex.js 1.0b3rc2 c0f1cd0975149d431c45b674ff88119d8c69d265cf7c9ffe6e8e7076397b27c5
@@ -7478,6 +7573,7 @@
 ./packages/api-utils/lib/cortex.js 1.9b2 7765b219e1e3c39a5109135343b572dcdc0a7ea8e1d9e21354ae66720ecf4ba0
 ./packages/api-utils/lib/cortex.js 1.9b3 7765b219e1e3c39a5109135343b572dcdc0a7ea8e1d9e21354ae66720ecf4ba0
 ./packages/api-utils/lib/cortex.js 1.9-dev 7765b219e1e3c39a5109135343b572dcdc0a7ea8e1d9e21354ae66720ecf4ba0
+./packages/api-utils/lib/cortex.js 1.9rc1 7765b219e1e3c39a5109135343b572dcdc0a7ea8e1d9e21354ae66720ecf4ba0
 ./packages/api-utils/lib/cuddlefish.js 1.0 3274cbadea4ce8b70dc67586308c32dc6abdf3fcd7fe6c8829a0c2b2c57172c0
 ./packages/api-utils/lib/cuddlefish.js 1.0b1 e4cdff130a0b5b6769f5c2b3d6c769f8c8e15d25cba19738840869e3df8c725d
 ./packages/api-utils/lib/cuddlefish.js 1.0b1rc1 e4cdff130a0b5b6769f5c2b3d6c769f8c8e15d25cba19738840869e3df8c725d
@@ -7569,6 +7665,7 @@
 ./packages/api-utils/lib/cuddlefish.js 1.9b2 025597db0eca7f2ef8ec809a591bdc76a583cdbaae9f675e046e7a164260b3e9
 ./packages/api-utils/lib/cuddlefish.js 1.9b3 025597db0eca7f2ef8ec809a591bdc76a583cdbaae9f675e046e7a164260b3e9
 ./packages/api-utils/lib/cuddlefish.js 1.9-dev 68d3b4edc7861ef25e80e672ea98c08e53aa97a173744aa3363cf47112bf9f03
+./packages/api-utils/lib/cuddlefish.js 1.9rc1 025597db0eca7f2ef8ec809a591bdc76a583cdbaae9f675e046e7a164260b3e9
 ./packages/api-utils/lib/dom/events.js 1.0 a49f13d3f2e5acd1666e393b05ca4e092775a1b4fa0f1b05ba6a194f2f294922
 ./packages/api-utils/lib/dom/events.js 1.0b5 a49f13d3f2e5acd1666e393b05ca4e092775a1b4fa0f1b05ba6a194f2f294922
 ./packages/api-utils/lib/dom/events.js 1.0b5rc1 a49f13d3f2e5acd1666e393b05ca4e092775a1b4fa0f1b05ba6a194f2f294922
@@ -7644,6 +7741,7 @@
 ./packages/api-utils/lib/dom/events.js 1.9b2 c4fc5994b6a4e0008cf52eaaa765a5ad313155946fa5be6ffd1b83396c3b576d
 ./packages/api-utils/lib/dom/events.js 1.9b3 c4fc5994b6a4e0008cf52eaaa765a5ad313155946fa5be6ffd1b83396c3b576d
 ./packages/api-utils/lib/dom/events.js 1.9-dev c4fc5994b6a4e0008cf52eaaa765a5ad313155946fa5be6ffd1b83396c3b576d
+./packages/api-utils/lib/dom/events.js 1.9rc1 c4fc5994b6a4e0008cf52eaaa765a5ad313155946fa5be6ffd1b83396c3b576d
 ./packages/api-utils/lib/dom/events/keys.js 1.0 62ce764f082f1e46cb8411fee15f4df77a208c596bbfbcf6ab4e546e95971d72
 ./packages/api-utils/lib/dom/events/keys.js 1.0b5 62ce764f082f1e46cb8411fee15f4df77a208c596bbfbcf6ab4e546e95971d72
 ./packages/api-utils/lib/dom/events/keys.js 1.0b5rc1 62ce764f082f1e46cb8411fee15f4df77a208c596bbfbcf6ab4e546e95971d72
@@ -7719,6 +7817,7 @@
 ./packages/api-utils/lib/dom/events/keys.js 1.9b2 658167eaeb1036abcb9d5747b4e7116034a18b7373cfc7060f5b0bb4a1f0efdc
 ./packages/api-utils/lib/dom/events/keys.js 1.9b3 658167eaeb1036abcb9d5747b4e7116034a18b7373cfc7060f5b0bb4a1f0efdc
 ./packages/api-utils/lib/dom/events/keys.js 1.9-dev 658167eaeb1036abcb9d5747b4e7116034a18b7373cfc7060f5b0bb4a1f0efdc
+./packages/api-utils/lib/dom/events/keys.js 1.9rc1 658167eaeb1036abcb9d5747b4e7116034a18b7373cfc7060f5b0bb4a1f0efdc
 ./packages/api-utils/lib/e10s.js 1.0 a376f3c8209e359021fa0b17199974e4ad8911117e1192949a68cf205c95d96a
 ./packages/api-utils/lib/e10s.js 1.0b1 8a13f3194c386d87cfdf1b6dd2be6e31b24be9178028cc8786eb1a6f39cd156a
 ./packages/api-utils/lib/e10s.js 1.0b1rc1 8a13f3194c386d87cfdf1b6dd2be6e31b24be9178028cc8786eb1a6f39cd156a
@@ -7810,6 +7909,7 @@
 ./packages/api-utils/lib/environment.js 1.9b2 d96f4609263ef09f541cbe4a9df8532594fbb01f642b0af632b71c95e70c4b0c
 ./packages/api-utils/lib/environment.js 1.9b3 d96f4609263ef09f541cbe4a9df8532594fbb01f642b0af632b71c95e70c4b0c
 ./packages/api-utils/lib/environment.js 1.9-dev d96f4609263ef09f541cbe4a9df8532594fbb01f642b0af632b71c95e70c4b0c
+./packages/api-utils/lib/environment.js 1.9rc1 d96f4609263ef09f541cbe4a9df8532594fbb01f642b0af632b71c95e70c4b0c
 ./packages/api-utils/lib/env!.js 1.4.1 c3b5047e7befbacb42cce1f7646901369e12e7ac45587388707876c8820ad747
 ./packages/api-utils/lib/env!.js 1.4.2 c3b5047e7befbacb42cce1f7646901369e12e7ac45587388707876c8820ad747
 ./packages/api-utils/lib/env!.js 1.4.3b1 c3b5047e7befbacb42cce1f7646901369e12e7ac45587388707876c8820ad747
@@ -7935,6 +8035,7 @@
 ./packages/api-utils/lib/errors.js 1.9b2 a9f3c34b8f0ed4b45c08e3691f934610cf4568d0c7031073df4e8c792b4c211e
 ./packages/api-utils/lib/errors.js 1.9b3 a9f3c34b8f0ed4b45c08e3691f934610cf4568d0c7031073df4e8c792b4c211e
 ./packages/api-utils/lib/errors.js 1.9-dev a9f3c34b8f0ed4b45c08e3691f934610cf4568d0c7031073df4e8c792b4c211e
+./packages/api-utils/lib/errors.js 1.9rc1 a9f3c34b8f0ed4b45c08e3691f934610cf4568d0c7031073df4e8c792b4c211e
 ./packages/api-utils/lib/es5.js 1.0b1 c27eecba751b5a0e411ff2b1b47c4af7c51b1fad113a0b38d047c9a740e9fc25
 ./packages/api-utils/lib/es5.js 1.0b1rc1 c27eecba751b5a0e411ff2b1b47c4af7c51b1fad113a0b38d047c9a740e9fc25
 ./packages/api-utils/lib/es5.js 1.0b1rc2 c27eecba751b5a0e411ff2b1b47c4af7c51b1fad113a0b38d047c9a740e9fc25
@@ -7974,6 +8075,7 @@
 ./packages/api-utils/lib/event/core.js 1.9b2 c48b9cb97880955dcc1127a6740f1f153010989752d180d0fb5c34b1093d59da
 ./packages/api-utils/lib/event/core.js 1.9b3 c48b9cb97880955dcc1127a6740f1f153010989752d180d0fb5c34b1093d59da
 ./packages/api-utils/lib/event/core.js 1.9-dev c48b9cb97880955dcc1127a6740f1f153010989752d180d0fb5c34b1093d59da
+./packages/api-utils/lib/event/core.js 1.9rc1 c48b9cb97880955dcc1127a6740f1f153010989752d180d0fb5c34b1093d59da
 ./packages/api-utils/lib/events/assembler.js 1.0 4e048c6dc31122f783257be78ee7c91eb3c596b150f959aeecd362a04d22a562
 ./packages/api-utils/lib/events/assembler.js 1.0b5 4e048c6dc31122f783257be78ee7c91eb3c596b150f959aeecd362a04d22a562
 ./packages/api-utils/lib/events/assembler.js 1.0b5rc1 4e048c6dc31122f783257be78ee7c91eb3c596b150f959aeecd362a04d22a562
@@ -8049,6 +8151,7 @@
 ./packages/api-utils/lib/events/assembler.js 1.9b2 d7d83af2f2b948340eb2960fc16246510f4ca594a5dda4e37e565b3f2fb747a5
 ./packages/api-utils/lib/events/assembler.js 1.9b3 d7d83af2f2b948340eb2960fc16246510f4ca594a5dda4e37e565b3f2fb747a5
 ./packages/api-utils/lib/events/assembler.js 1.9-dev d7d83af2f2b948340eb2960fc16246510f4ca594a5dda4e37e565b3f2fb747a5
+./packages/api-utils/lib/events/assembler.js 1.9rc1 d7d83af2f2b948340eb2960fc16246510f4ca594a5dda4e37e565b3f2fb747a5
 ./packages/api-utils/lib/events.js 1.0b1 920fd7612130c1e6408fead4703d515c6fcc3e088605fc18fee05961c08cc764
 ./packages/api-utils/lib/events.js 1.0b1rc1 effdcb5baf0eed2d04162def04d252dff69619c084da7f250a672650686c415d
 ./packages/api-utils/lib/events.js 1.0b1rc2 920fd7612130c1e6408fead4703d515c6fcc3e088605fc18fee05961c08cc764
@@ -8140,6 +8243,7 @@
 ./packages/api-utils/lib/events.js 1.9b2 7d52b7d9931d4f94cb2da1745165f399f9ce637df0c25969259e14140a024b73
 ./packages/api-utils/lib/events.js 1.9b3 7d52b7d9931d4f94cb2da1745165f399f9ce637df0c25969259e14140a024b73
 ./packages/api-utils/lib/events.js 1.9-dev 7d52b7d9931d4f94cb2da1745165f399f9ce637df0c25969259e14140a024b73
+./packages/api-utils/lib/events.js 1.9rc1 7d52b7d9931d4f94cb2da1745165f399f9ce637df0c25969259e14140a024b73
 ./packages/api-utils/lib/event/target.js 1.10-dev ba97456b211cc8490ed793a4b8ab8e54d1adba08853ea4e2d82021a436e4ad85
 ./packages/api-utils/lib/event/target.js 1.7 59485a777072dabeffa8ec3b407b52c5e9482f80de3b0cf1b9005fe2fc12200c
 ./packages/api-utils/lib/event/target.js 1.7b1 59485a777072dabeffa8ec3b407b52c5e9482f80de3b0cf1b9005fe2fc12200c
@@ -8160,6 +8264,7 @@
 ./packages/api-utils/lib/event/target.js 1.9b2 ba97456b211cc8490ed793a4b8ab8e54d1adba08853ea4e2d82021a436e4ad85
 ./packages/api-utils/lib/event/target.js 1.9b3 ba97456b211cc8490ed793a4b8ab8e54d1adba08853ea4e2d82021a436e4ad85
 ./packages/api-utils/lib/event/target.js 1.9-dev ba97456b211cc8490ed793a4b8ab8e54d1adba08853ea4e2d82021a436e4ad85
+./packages/api-utils/lib/event/target.js 1.9rc1 ba97456b211cc8490ed793a4b8ab8e54d1adba08853ea4e2d82021a436e4ad85
 ./packages/api-utils/lib/file.js 1.0 30312539fbd6cf3e59b88c394d2acf6f9b4bc02f892d855e55d71e8ad7683c31
 ./packages/api-utils/lib/file.js 1.0b1 07f4cf3bbed048b9cfd42af3ca15baf019005e692b62b8d28494b23b5e569ca5
 ./packages/api-utils/lib/file.js 1.0b1rc1 07f4cf3bbed048b9cfd42af3ca15baf019005e692b62b8d28494b23b5e569ca5
@@ -8251,6 +8356,7 @@
 ./packages/api-utils/lib/file.js 1.9b2 d9f0ff832e14d93aa74150db5f69ad57c2f28248f69d726d164cb118c8717b29
 ./packages/api-utils/lib/file.js 1.9b3 d9f0ff832e14d93aa74150db5f69ad57c2f28248f69d726d164cb118c8717b29
 ./packages/api-utils/lib/file.js 1.9-dev d9f0ff832e14d93aa74150db5f69ad57c2f28248f69d726d164cb118c8717b29
+./packages/api-utils/lib/file.js 1.9rc1 d9f0ff832e14d93aa74150db5f69ad57c2f28248f69d726d164cb118c8717b29
 ./packages/api-utils/lib/find-tests-e10s-adapter.js 1.0 a986a1663580ef3fcd121d87f636d87c69ed37b4345da40d136cc8fb06d31a5f
 ./packages/api-utils/lib/find-tests-e10s-adapter.js 1.0b1 0f5f0a457d029b5125aa6855a089e88da9cb92c7840a9ea3f56003a5b38bb52b
 ./packages/api-utils/lib/find-tests-e10s-adapter.js 1.0b1rc1 0f5f0a457d029b5125aa6855a089e88da9cb92c7840a9ea3f56003a5b38bb52b
@@ -8385,6 +8491,7 @@
 ./packages/api-utils/lib/find-tests.js 1.9b2 810b9aa6d9b1b2a0e4dad35f93d2d6e7fb2125675916c974214919d3ec7b8b9d
 ./packages/api-utils/lib/find-tests.js 1.9b3 810b9aa6d9b1b2a0e4dad35f93d2d6e7fb2125675916c974214919d3ec7b8b9d
 ./packages/api-utils/lib/find-tests.js 1.9-dev 810b9aa6d9b1b2a0e4dad35f93d2d6e7fb2125675916c974214919d3ec7b8b9d
+./packages/api-utils/lib/find-tests.js 1.9rc1 810b9aa6d9b1b2a0e4dad35f93d2d6e7fb2125675916c974214919d3ec7b8b9d
 ./packages/api-utils/lib/frame/utils.js 1.10-dev b128c62b6c8749ccba4ed64e3476f6f565457648fc75ef14407ab77f9947c6a4
 ./packages/api-utils/lib/frame/utils.js 1.7 b128c62b6c8749ccba4ed64e3476f6f565457648fc75ef14407ab77f9947c6a4
 ./packages/api-utils/lib/frame/utils.js 1.7b1 b128c62b6c8749ccba4ed64e3476f6f565457648fc75ef14407ab77f9947c6a4
@@ -8405,6 +8512,7 @@
 ./packages/api-utils/lib/frame/utils.js 1.9b2 b128c62b6c8749ccba4ed64e3476f6f565457648fc75ef14407ab77f9947c6a4
 ./packages/api-utils/lib/frame/utils.js 1.9b3 b128c62b6c8749ccba4ed64e3476f6f565457648fc75ef14407ab77f9947c6a4
 ./packages/api-utils/lib/frame/utils.js 1.9-dev b128c62b6c8749ccba4ed64e3476f6f565457648fc75ef14407ab77f9947c6a4
+./packages/api-utils/lib/frame/utils.js 1.9rc1 b128c62b6c8749ccba4ed64e3476f6f565457648fc75ef14407ab77f9947c6a4
 ./packages/api-utils/lib/functional.js 1.10-dev 251780f6cea3aaefcccc202ca69cce53d5a2214205dd465e7c754b126dd44dea
 ./packages/api-utils/lib/functional.js 1.6.1 848e921e776f4bdd5c132bdf451442e8a7a1e482f91963bc8b6f63dec0b09135
 ./packages/api-utils/lib/functional.js 1.6.1rc1 848e921e776f4bdd5c132bdf451442e8a7a1e482f91963bc8b6f63dec0b09135
@@ -8433,6 +8541,7 @@
 ./packages/api-utils/lib/functional.js 1.9b2 251780f6cea3aaefcccc202ca69cce53d5a2214205dd465e7c754b126dd44dea
 ./packages/api-utils/lib/functional.js 1.9b3 251780f6cea3aaefcccc202ca69cce53d5a2214205dd465e7c754b126dd44dea
 ./packages/api-utils/lib/functional.js 1.9-dev 251780f6cea3aaefcccc202ca69cce53d5a2214205dd465e7c754b126dd44dea
+./packages/api-utils/lib/functional.js 1.9rc1 251780f6cea3aaefcccc202ca69cce53d5a2214205dd465e7c754b126dd44dea
 ./packages/api-utils/lib/globals.js 1.10-dev 722f596997270ba79b12cd6f3b1a68fc3781148df80a540b6238f57cd5658734
 ./packages/api-utils/lib/globals!.js 1.4.1 fd7d9a0b378583896e960b2de37218e39fb835760ffdf820cd1c39e50d668199
 ./packages/api-utils/lib/globals!.js 1.4.2 1453c26694be1ac1d9ad590ff640bcf217cbc07fa86b800221303ba9f527f61b
@@ -8481,6 +8590,7 @@
 ./packages/api-utils/lib/globals.js 1.9b2 722f596997270ba79b12cd6f3b1a68fc3781148df80a540b6238f57cd5658734
 ./packages/api-utils/lib/globals.js 1.9b3 722f596997270ba79b12cd6f3b1a68fc3781148df80a540b6238f57cd5658734
 ./packages/api-utils/lib/globals!.js 1.9-dev d634d17b53cdfda3bb27a8f6ac310a859d6ead84626b78e72edffb4724cc7585
+./packages/api-utils/lib/globals.js 1.9rc1 31580a972c125bda7ef670a334b489921072e0edabd9b1ffa4f6aa6ae831ef2c
 ./packages/api-utils/lib/heritage.js 1.10-dev 5c9078a92d5d2ce130086c648cb6a31ae9e140aa223089a092efbe0904ad0531
 ./packages/api-utils/lib/heritage.js 1.8.1 4f9cab57419f5e651fc3e41dfb724694a70ee6d30187c583c3459f78e5065c70
 ./packages/api-utils/lib/heritage.js 1.8.2 4f9cab57419f5e651fc3e41dfb724694a70ee6d30187c583c3459f78e5065c70
@@ -8495,6 +8605,7 @@
 ./packages/api-utils/lib/heritage.js 1.9b2 5c9078a92d5d2ce130086c648cb6a31ae9e140aa223089a092efbe0904ad0531
 ./packages/api-utils/lib/heritage.js 1.9b3 5c9078a92d5d2ce130086c648cb6a31ae9e140aa223089a092efbe0904ad0531
 ./packages/api-utils/lib/heritage.js 1.9-dev 4f9cab57419f5e651fc3e41dfb724694a70ee6d30187c583c3459f78e5065c70
+./packages/api-utils/lib/heritage.js 1.9rc1 5c9078a92d5d2ce130086c648cb6a31ae9e140aa223089a092efbe0904ad0531
 ./packages/api-utils/lib/hidden-frame.js 1.0 84d23d836193f98e5f6e0db78d4fee33d97c04b1a7799b8f3ec48a83f5392cc6
 ./packages/api-utils/lib/hidden-frame.js 1.0b1 84d23d836193f98e5f6e0db78d4fee33d97c04b1a7799b8f3ec48a83f5392cc6
 ./packages/api-utils/lib/hidden-frame.js 1.0b1rc1 84d23d836193f98e5f6e0db78d4fee33d97c04b1a7799b8f3ec48a83f5392cc6
@@ -8586,6 +8697,7 @@
 ./packages/api-utils/lib/hidden-frame.js 1.9b2 89acb3960fbc5ff9b03d48f866dadb6679b4a12decd92d9d7935051de5b6e9f4
 ./packages/api-utils/lib/hidden-frame.js 1.9b3 89acb3960fbc5ff9b03d48f866dadb6679b4a12decd92d9d7935051de5b6e9f4
 ./packages/api-utils/lib/hidden-frame.js 1.9-dev 89acb3960fbc5ff9b03d48f866dadb6679b4a12decd92d9d7935051de5b6e9f4
+./packages/api-utils/lib/hidden-frame.js 1.9rc1 89acb3960fbc5ff9b03d48f866dadb6679b4a12decd92d9d7935051de5b6e9f4
 ./packages/api-utils/lib/httpd.js 1.10-dev b4c02582fcb98ab697792b7e94fbbba1ff8b31c7c670e8330e73366b7f2c135b
 ./packages/api-utils/lib/httpd.js 1.4 0123946406fc1d2bfab2b42a71df41243c39f43e4e153fe42f705dd94bd2adae
 ./packages/api-utils/lib/httpd.js 1.4.1 0123946406fc1d2bfab2b42a71df41243c39f43e4e153fe42f705dd94bd2adae
@@ -8634,6 +8746,7 @@
 ./packages/api-utils/lib/httpd.js 1.9b2 b4c02582fcb98ab697792b7e94fbbba1ff8b31c7c670e8330e73366b7f2c135b
 ./packages/api-utils/lib/httpd.js 1.9b3 b4c02582fcb98ab697792b7e94fbbba1ff8b31c7c670e8330e73366b7f2c135b
 ./packages/api-utils/lib/httpd.js 1.9-dev cf13f11557aaa406530013dd75090249959981aef9502c2f523921423f1d5a0b
+./packages/api-utils/lib/httpd.js 1.9rc1 b844003c9d4cb3b3defa4dbfd3f34afbfced44097f78c65fe51a6334d7ea459b
 ./packages/api-utils/lib/keyboard/hotkeys.js 1.0 61c285f75c90646c8b74364e9f34197d4afc293fac8663b73f6753ac72eb147e
 ./packages/api-utils/lib/keyboard/hotkeys.js 1.0b5 61c285f75c90646c8b74364e9f34197d4afc293fac8663b73f6753ac72eb147e
 ./packages/api-utils/lib/keyboard/hotkeys.js 1.0b5rc1 61c285f75c90646c8b74364e9f34197d4afc293fac8663b73f6753ac72eb147e
@@ -8709,6 +8822,7 @@
 ./packages/api-utils/lib/keyboard/hotkeys.js 1.9b2 acb090facf9fed8109986c28dd12c9088349053e6f47135c1d1dd50ff788d5b8
 ./packages/api-utils/lib/keyboard/hotkeys.js 1.9b3 acb090facf9fed8109986c28dd12c9088349053e6f47135c1d1dd50ff788d5b8
 ./packages/api-utils/lib/keyboard/hotkeys.js 1.9-dev acb090facf9fed8109986c28dd12c9088349053e6f47135c1d1dd50ff788d5b8
+./packages/api-utils/lib/keyboard/hotkeys.js 1.9rc1 acb090facf9fed8109986c28dd12c9088349053e6f47135c1d1dd50ff788d5b8
 ./packages/api-utils/lib/keyboard/observer.js 1.0 60702f8164c01d0f31f434a51e2751ef65413dd7ac97dab00536a1d7cfac4658
 ./packages/api-utils/lib/keyboard/observer.js 1.0b5 60702f8164c01d0f31f434a51e2751ef65413dd7ac97dab00536a1d7cfac4658
 ./packages/api-utils/lib/keyboard/observer.js 1.0b5rc1 60702f8164c01d0f31f434a51e2751ef65413dd7ac97dab00536a1d7cfac4658
@@ -8784,6 +8898,7 @@
 ./packages/api-utils/lib/keyboard/observer.js 1.9b2 0d568761bfca1239cd60991a34b3ccd3f35dd3780b0cf354e1184f178e501f5e
 ./packages/api-utils/lib/keyboard/observer.js 1.9b3 0d568761bfca1239cd60991a34b3ccd3f35dd3780b0cf354e1184f178e501f5e
 ./packages/api-utils/lib/keyboard/observer.js 1.9-dev 80f81f8a7a30b41611e263811dba3bf45058e545add2f71c45cfb5cc435474f5
+./packages/api-utils/lib/keyboard/observer.js 1.9rc1 0d568761bfca1239cd60991a34b3ccd3f35dd3780b0cf354e1184f178e501f5e
 ./packages/api-utils/lib/keyboard/utils.js 1.0 872eaa27fff845edf8916dcb20d8f3c9b593a4903e69e8c204bb5e678aeac0c7
 ./packages/api-utils/lib/keyboard/utils.js 1.0b5 872eaa27fff845edf8916dcb20d8f3c9b593a4903e69e8c204bb5e678aeac0c7
 ./packages/api-utils/lib/keyboard/utils.js 1.0b5rc1 872eaa27fff845edf8916dcb20d8f3c9b593a4903e69e8c204bb5e678aeac0c7
@@ -8859,6 +8974,7 @@
 ./packages/api-utils/lib/keyboard/utils.js 1.9b2 ac1f4b03beecb2189c7242ebdeaa2a1236ef8bf95c5884833b1515a2175d8494
 ./packages/api-utils/lib/keyboard/utils.js 1.9b3 ac1f4b03beecb2189c7242ebdeaa2a1236ef8bf95c5884833b1515a2175d8494
 ./packages/api-utils/lib/keyboard/utils.js 1.9-dev ac1f4b03beecb2189c7242ebdeaa2a1236ef8bf95c5884833b1515a2175d8494
+./packages/api-utils/lib/keyboard/utils.js 1.9rc1 ac1f4b03beecb2189c7242ebdeaa2a1236ef8bf95c5884833b1515a2175d8494
 ./packages/api-utils/lib/l10n/core.js 1.10-dev 593b43ee361cf8eff44aa2590088dc3a3b0aa73826663db52aef09b56e6dc0cd
 ./packages/api-utils/lib/l10n/core.js 1.8.1 65d705c3b231545c342b7a6e0f3c76fa35719641f7f9d69546525ca556a7d932
 ./packages/api-utils/lib/l10n/core.js 1.8.2 65d705c3b231545c342b7a6e0f3c76fa35719641f7f9d69546525ca556a7d932
@@ -8873,6 +8989,7 @@
 ./packages/api-utils/lib/l10n/core.js 1.9b2 593b43ee361cf8eff44aa2590088dc3a3b0aa73826663db52aef09b56e6dc0cd
 ./packages/api-utils/lib/l10n/core.js 1.9b3 593b43ee361cf8eff44aa2590088dc3a3b0aa73826663db52aef09b56e6dc0cd
 ./packages/api-utils/lib/l10n/core.js 1.9-dev 65d705c3b231545c342b7a6e0f3c76fa35719641f7f9d69546525ca556a7d932
+./packages/api-utils/lib/l10n/core.js 1.9rc1 593b43ee361cf8eff44aa2590088dc3a3b0aa73826663db52aef09b56e6dc0cd
 ./packages/api-utils/lib/l10n/html.js 1.10-dev d932a4f4bb3d4626d01867fc692bc79b41fc65b6105185bc444c4ddf60cc768f
 ./packages/api-utils/lib/l10n/html.js 1.8.1 4c3c13c791b703cf19d1a41c71ac9f0b1a269316e11ced09a3402e157a6fff13
 ./packages/api-utils/lib/l10n/html.js 1.8.2 4c3c13c791b703cf19d1a41c71ac9f0b1a269316e11ced09a3402e157a6fff13
@@ -8887,6 +9004,7 @@
 ./packages/api-utils/lib/l10n/html.js 1.9b2 d932a4f4bb3d4626d01867fc692bc79b41fc65b6105185bc444c4ddf60cc768f
 ./packages/api-utils/lib/l10n/html.js 1.9b3 d932a4f4bb3d4626d01867fc692bc79b41fc65b6105185bc444c4ddf60cc768f
 ./packages/api-utils/lib/l10n/html.js 1.9-dev 4c3c13c791b703cf19d1a41c71ac9f0b1a269316e11ced09a3402e157a6fff13
+./packages/api-utils/lib/l10n/html.js 1.9rc1 d932a4f4bb3d4626d01867fc692bc79b41fc65b6105185bc444c4ddf60cc768f
 ./packages/api-utils/lib/l10n/locale.js 1.10-dev a9f7f348af3544720893a21b7466c05dec43cb9c4cac4c8bd5acea51d17c788c
 ./packages/api-utils/lib/l10n/locale.js 1.6.1 a9f7f348af3544720893a21b7466c05dec43cb9c4cac4c8bd5acea51d17c788c
 ./packages/api-utils/lib/l10n/locale.js 1.6.1rc1 a9f7f348af3544720893a21b7466c05dec43cb9c4cac4c8bd5acea51d17c788c
@@ -8915,6 +9033,7 @@
 ./packages/api-utils/lib/l10n/locale.js 1.9b2 a9f7f348af3544720893a21b7466c05dec43cb9c4cac4c8bd5acea51d17c788c
 ./packages/api-utils/lib/l10n/locale.js 1.9b3 a9f7f348af3544720893a21b7466c05dec43cb9c4cac4c8bd5acea51d17c788c
 ./packages/api-utils/lib/l10n/locale.js 1.9-dev a9f7f348af3544720893a21b7466c05dec43cb9c4cac4c8bd5acea51d17c788c
+./packages/api-utils/lib/l10n/locale.js 1.9rc1 a9f7f348af3544720893a21b7466c05dec43cb9c4cac4c8bd5acea51d17c788c
 ./packages/api-utils/lib/l10n/plural-rules.js 1.10-dev bf22c1f33e35c3a83e1756e16cc171e0d73121d410c112310db82759e1f95f7f
 ./packages/api-utils/lib/l10n/plural-rules.js 1.7 895bce6fc80a8505e74ae00819095d281b8798b5fe3521ec22af83a4260fc9cf
 ./packages/api-utils/lib/l10n/plural-rules.js 1.7b1 895bce6fc80a8505e74ae00819095d281b8798b5fe3521ec22af83a4260fc9cf
@@ -8935,6 +9054,7 @@
 ./packages/api-utils/lib/l10n/plural-rules.js 1.9b2 bf22c1f33e35c3a83e1756e16cc171e0d73121d410c112310db82759e1f95f7f
 ./packages/api-utils/lib/l10n/plural-rules.js 1.9b3 bf22c1f33e35c3a83e1756e16cc171e0d73121d410c112310db82759e1f95f7f
 ./packages/api-utils/lib/l10n/plural-rules.js 1.9-dev bf22c1f33e35c3a83e1756e16cc171e0d73121d410c112310db82759e1f95f7f
+./packages/api-utils/lib/l10n/plural-rules.js 1.9rc1 bf22c1f33e35c3a83e1756e16cc171e0d73121d410c112310db82759e1f95f7f
 ./packages/api-utils/lib/light-traits.js 1.0b3 eb07416982e7ccfb3dee68efd256c0dd09a04d65f34cbdab90b88f0874af00c4
 ./packages/api-utils/lib/light-traits.js 1.0b3rc1 eb07416982e7ccfb3dee68efd256c0dd09a04d65f34cbdab90b88f0874af00c4
 ./packages/api-utils/lib/light-traits.js 1.0b3rc2 eb07416982e7ccfb3dee68efd256c0dd09a04d65f34cbdab90b88f0874af00c4
@@ -9019,6 +9139,7 @@
 ./packages/api-utils/lib/light-traits.js 1.9b2 8d00d1661a149cf6e1ac50354418c4ac24e9d692b40ef8976ae481373d8bfb2c
 ./packages/api-utils/lib/light-traits.js 1.9b3 8d00d1661a149cf6e1ac50354418c4ac24e9d692b40ef8976ae481373d8bfb2c
 ./packages/api-utils/lib/light-traits.js 1.9-dev 8d00d1661a149cf6e1ac50354418c4ac24e9d692b40ef8976ae481373d8bfb2c
+./packages/api-utils/lib/light-traits.js 1.9rc1 8d00d1661a149cf6e1ac50354418c4ac24e9d692b40ef8976ae481373d8bfb2c
 ./packages/api-utils/lib/list.js 1.0b1 115b850fdf9c6114b11403fae45047d77f810669951301788c74235a18b1cda3
 ./packages/api-utils/lib/list.js 1.0b1rc1 115b850fdf9c6114b11403fae45047d77f810669951301788c74235a18b1cda3
 ./packages/api-utils/lib/list.js 1.0b1rc2 115b850fdf9c6114b11403fae45047d77f810669951301788c74235a18b1cda3
@@ -9110,10 +9231,12 @@
 ./packages/api-utils/lib/list.js 1.9b2 47fa2de01fecdf891bf8fee3ca7103e82d1d5ab32623513ab286b8939e56b079
 ./packages/api-utils/lib/list.js 1.9b3 47fa2de01fecdf891bf8fee3ca7103e82d1d5ab32623513ab286b8939e56b079
 ./packages/api-utils/lib/list.js 1.9-dev 47fa2de01fecdf891bf8fee3ca7103e82d1d5ab32623513ab286b8939e56b079
+./packages/api-utils/lib/list.js 1.9rc1 47fa2de01fecdf891bf8fee3ca7103e82d1d5ab32623513ab286b8939e56b079
 ./packages/api-utils/lib/loader.js 1.10-dev 2f858f809a2624ab1ec86d9bc78e2fccabfd2b4745f2051640be33851e4d395f
 ./packages/api-utils/lib/loader.js 1.9b1 2f858f809a2624ab1ec86d9bc78e2fccabfd2b4745f2051640be33851e4d395f
 ./packages/api-utils/lib/loader.js 1.9b2 2f858f809a2624ab1ec86d9bc78e2fccabfd2b4745f2051640be33851e4d395f
 ./packages/api-utils/lib/loader.js 1.9b3 2f858f809a2624ab1ec86d9bc78e2fccabfd2b4745f2051640be33851e4d395f
+./packages/api-utils/lib/loader.js 1.9rc1 afa2814001cda5db5085654761e22b07635424ef50000ece208048662fd6655a
 ./packages/api-utils/lib/match-pattern.js 1.0 25233c958394bcf60c6c3c62776ec92495f1b3788cf8787490b2f89241fcf81e
 ./packages/api-utils/lib/match-pattern.js 1.0b1 35308939642e1a322f412edcc248d8da806bdbdcb081a2eeae11409d1b5bed0d
 ./packages/api-utils/lib/match-pattern.js 1.0b1rc1 35308939642e1a322f412edcc248d8da806bdbdcb081a2eeae11409d1b5bed0d
@@ -9205,6 +9328,7 @@
 ./packages/api-utils/lib/match-pattern.js 1.9b2 16f330e4d0eba08f53cf98631353552395e7f17e7273c0005273fcf9e7722518
 ./packages/api-utils/lib/match-pattern.js 1.9b3 16f330e4d0eba08f53cf98631353552395e7f17e7273c0005273fcf9e7722518
 ./packages/api-utils/lib/match-pattern.js 1.9-dev 16f330e4d0eba08f53cf98631353552395e7f17e7273c0005273fcf9e7722518
+./packages/api-utils/lib/match-pattern.js 1.9rc1 16f330e4d0eba08f53cf98631353552395e7f17e7273c0005273fcf9e7722518
 ./packages/api-utils/lib/memory.js 1.0 86fa63a9b8597b3d79eee674b1d4c71462a61019a143681bb2b7e00d17462e65
 ./packages/api-utils/lib/memory.js 1.0b1 86fa63a9b8597b3d79eee674b1d4c71462a61019a143681bb2b7e00d17462e65
 ./packages/api-utils/lib/memory.js 1.0b1rc1 86fa63a9b8597b3d79eee674b1d4c71462a61019a143681bb2b7e00d17462e65
@@ -9296,6 +9420,7 @@
 ./packages/api-utils/lib/memory.js 1.9b2 f41b28860ac61fc69d05be491fc52d0babf109c25aee9a464db18bacd6b9bfd5
 ./packages/api-utils/lib/memory.js 1.9b3 f41b28860ac61fc69d05be491fc52d0babf109c25aee9a464db18bacd6b9bfd5
 ./packages/api-utils/lib/memory.js 1.9-dev f41b28860ac61fc69d05be491fc52d0babf109c25aee9a464db18bacd6b9bfd5
+./packages/api-utils/lib/memory.js 1.9rc1 f41b28860ac61fc69d05be491fc52d0babf109c25aee9a464db18bacd6b9bfd5
 ./packages/api-utils/lib/message-manager.js 1.5 014b63ea47da6e17be09bb8b2c3d0eff8574b6f2524054c3895f21ad1049bb27
 ./packages/api-utils/lib/message-manager.js 1.5b1 014b63ea47da6e17be09bb8b2c3d0eff8574b6f2524054c3895f21ad1049bb27
 ./packages/api-utils/lib/message-manager.js 1.5b2 014b63ea47da6e17be09bb8b2c3d0eff8574b6f2524054c3895f21ad1049bb27
@@ -9365,6 +9490,7 @@
 ./packages/api-utils/lib/namespace.js 1.9b2 b668cfe8db6d69675a663eaa3edd6f29c11b9ca96c8da3cf333cbe8607ba0fea
 ./packages/api-utils/lib/namespace.js 1.9b3 b668cfe8db6d69675a663eaa3edd6f29c11b9ca96c8da3cf333cbe8607ba0fea
 ./packages/api-utils/lib/namespace.js 1.9-dev 0523a0c70f17b03d600920e64bca31d52e12c8a6bed0a3a7c6d87c10ae79f1d0
+./packages/api-utils/lib/namespace.js 1.9rc1 b668cfe8db6d69675a663eaa3edd6f29c11b9ca96c8da3cf333cbe8607ba0fea
 ./packages/api-utils/lib/observer-service.js 1.0 8ba7c79769994139a4d386fa188e596951f9de10bee009fb153d3a035927116d
 ./packages/api-utils/lib/observer-service.js 1.0b1 8ba7c79769994139a4d386fa188e596951f9de10bee009fb153d3a035927116d
 ./packages/api-utils/lib/observer-service.js 1.0b1rc1 8ba7c79769994139a4d386fa188e596951f9de10bee009fb153d3a035927116d
@@ -9456,6 +9582,7 @@
 ./packages/api-utils/lib/observer-service.js 1.9b2 1bfe59b993d8f1f9d37f876606751f40687aa61a86463d03c7f969f10b9096bb
 ./packages/api-utils/lib/observer-service.js 1.9b3 1bfe59b993d8f1f9d37f876606751f40687aa61a86463d03c7f969f10b9096bb
 ./packages/api-utils/lib/observer-service.js 1.9-dev 1ae4071afb4df9664bc34637ac54b90fa153d04be610d9ce19183a9b636847f0
+./packages/api-utils/lib/observer-service.js 1.9rc1 1bfe59b993d8f1f9d37f876606751f40687aa61a86463d03c7f969f10b9096bb
 ./packages/api-utils/lib/passwords/utils.js 1.0 a16a234992e20c8837c9315ef6d403f4adb4363e12dedcda5bf97ebe1e73fd9c
 ./packages/api-utils/lib/passwords/utils.js 1.0b4.1 a16a234992e20c8837c9315ef6d403f4adb4363e12dedcda5bf97ebe1e73fd9c
 ./packages/api-utils/lib/passwords/utils.js 1.0b4 a16a234992e20c8837c9315ef6d403f4adb4363e12dedcda5bf97ebe1e73fd9c
@@ -9536,6 +9663,7 @@
 ./packages/api-utils/lib/passwords/utils.js 1.9b2 a05bed86fae67c7c02844ef34b6a371c929b8c13394f50b5e06fb2337e27a6f2
 ./packages/api-utils/lib/passwords/utils.js 1.9b3 a05bed86fae67c7c02844ef34b6a371c929b8c13394f50b5e06fb2337e27a6f2
 ./packages/api-utils/lib/passwords/utils.js 1.9-dev 388d9caa60edbad4aebec66c08f3c76e1256aa721b4a2c603fc13cf3801932ea
+./packages/api-utils/lib/passwords/utils.js 1.9rc1 a05bed86fae67c7c02844ef34b6a371c929b8c13394f50b5e06fb2337e27a6f2
 ./packages/api-utils/lib/plain-text-console.js 1.0 898a53a458779b8466fbb0c571f4018951aac32f073153e0f04309f798f6b8ab
 ./packages/api-utils/lib/plain-text-console.js 1.0b1 3686ac9aff6a7a54b55568e36121f4f45d81e62384df15d4fcf2567c70b108b7
 ./packages/api-utils/lib/plain-text-console.js 1.0b1rc1 3686ac9aff6a7a54b55568e36121f4f45d81e62384df15d4fcf2567c70b108b7
@@ -9627,6 +9755,7 @@
 ./packages/api-utils/lib/plain-text-console.js 1.9b2 42c7855906a65e3b39451245c6e5f682494bac2c6557b6ace14faecb714cbff6
 ./packages/api-utils/lib/plain-text-console.js 1.9b3 42c7855906a65e3b39451245c6e5f682494bac2c6557b6ace14faecb714cbff6
 ./packages/api-utils/lib/plain-text-console.js 1.9-dev 42c7855906a65e3b39451245c6e5f682494bac2c6557b6ace14faecb714cbff6
+./packages/api-utils/lib/plain-text-console.js 1.9rc1 42c7855906a65e3b39451245c6e5f682494bac2c6557b6ace14faecb714cbff6
 ./packages/api-utils/lib/preferences-service.js 1.0b1 17caf4bb572a892e2dbd08ad3ccb90d61a9355e955e709f55bdff3181c90d2e9
 ./packages/api-utils/lib/preferences-service.js 1.0b1rc1 17caf4bb572a892e2dbd08ad3ccb90d61a9355e955e709f55bdff3181c90d2e9
 ./packages/api-utils/lib/preferences-service.js 1.0b1rc2 17caf4bb572a892e2dbd08ad3ccb90d61a9355e955e709f55bdff3181c90d2e9
@@ -9718,10 +9847,12 @@
 ./packages/api-utils/lib/preferences-service.js 1.9b2 fc8688186754bee871eb50c5fc644366019b455e0a9a0bea942bf09ce4129b3b
 ./packages/api-utils/lib/preferences-service.js 1.9b3 fc8688186754bee871eb50c5fc644366019b455e0a9a0bea942bf09ce4129b3b
 ./packages/api-utils/lib/preferences-service.js 1.9-dev 25ef156752183357a96a61c87b2e5e6e5a250c1566e2b9af835ac84f53c60410
+./packages/api-utils/lib/preferences-service.js 1.9rc1 fc8688186754bee871eb50c5fc644366019b455e0a9a0bea942bf09ce4129b3b
 ./packages/api-utils/lib/prefs/target.js 1.10-dev 0da2d8b209a9958d759a1326e65fc8bc75bf6c05cae82d62ee534dc12b403be0
 ./packages/api-utils/lib/prefs/target.js 1.9b1 0da2d8b209a9958d759a1326e65fc8bc75bf6c05cae82d62ee534dc12b403be0
 ./packages/api-utils/lib/prefs/target.js 1.9b2 0da2d8b209a9958d759a1326e65fc8bc75bf6c05cae82d62ee534dc12b403be0
 ./packages/api-utils/lib/prefs/target.js 1.9b3 0da2d8b209a9958d759a1326e65fc8bc75bf6c05cae82d62ee534dc12b403be0
+./packages/api-utils/lib/prefs/target.js 1.9rc1 0da2d8b209a9958d759a1326e65fc8bc75bf6c05cae82d62ee534dc12b403be0
 ./packages/api-utils/lib/process.js 1.4.1 acdb8079ff87b7706018e8941bed0a598e6cd57763de9a2ea61878a6217cbb2e
 ./packages/api-utils/lib/process.js 1.4.2 acdb8079ff87b7706018e8941bed0a598e6cd57763de9a2ea61878a6217cbb2e
 ./packages/api-utils/lib/process.js 1.4.3 acdb8079ff87b7706018e8941bed0a598e6cd57763de9a2ea61878a6217cbb2e
@@ -9776,6 +9907,7 @@
 ./packages/api-utils/lib/promise.js 1.9b2 0b36a2d7d5d3fb4281c3997586a94d73e373167f9bf9f69d9204efb0349191c9
 ./packages/api-utils/lib/promise.js 1.9b3 0b36a2d7d5d3fb4281c3997586a94d73e373167f9bf9f69d9204efb0349191c9
 ./packages/api-utils/lib/promise.js 1.9-dev faa545f0b62e2b7eb413e0e04c062659df4a6c6073464cde3302640b9d089dba
+./packages/api-utils/lib/promise.js 1.9rc1 0b36a2d7d5d3fb4281c3997586a94d73e373167f9bf9f69d9204efb0349191c9
 ./packages/api-utils/lib/querystring.js 1.10-dev f4a189249c63e83de8a8a9a3ea6d3e3d663c29d44d36c953d437fb7c6491c0bc
 ./packages/api-utils/lib/querystring.js 1.7b1 f4a189249c63e83de8a8a9a3ea6d3e3d663c29d44d36c953d437fb7c6491c0bc
 ./packages/api-utils/lib/querystring.js 1.7b2 f4a189249c63e83de8a8a9a3ea6d3e3d663c29d44d36c953d437fb7c6491c0bc
@@ -9796,6 +9928,7 @@
 ./packages/api-utils/lib/querystring.js 1.9b2 f4a189249c63e83de8a8a9a3ea6d3e3d663c29d44d36c953d437fb7c6491c0bc
 ./packages/api-utils/lib/querystring.js 1.9b3 f4a189249c63e83de8a8a9a3ea6d3e3d663c29d44d36c953d437fb7c6491c0bc
 ./packages/api-utils/lib/querystring.js 1.9-dev f4a189249c63e83de8a8a9a3ea6d3e3d663c29d44d36c953d437fb7c6491c0bc
+./packages/api-utils/lib/querystring.js 1.9rc1 f4a189249c63e83de8a8a9a3ea6d3e3d663c29d44d36c953d437fb7c6491c0bc
 ./packages/api-utils/lib/runtime.js 1.0b5 c8eebe41b5a4e026538d35bddd8c8639cb81ba76dfef9b834cc59f71f42c2e80
 ./packages/api-utils/lib/runtime.js 1.0b5rc1 c8eebe41b5a4e026538d35bddd8c8639cb81ba76dfef9b834cc59f71f42c2e80
 ./packages/api-utils/lib/runtime.js 1.0b5rc2 c8eebe41b5a4e026538d35bddd8c8639cb81ba76dfef9b834cc59f71f42c2e80
@@ -9871,6 +10004,7 @@
 ./packages/api-utils/lib/runtime.js 1.9b2 c890d46b04876a2bdebcc9fade057fea2ba0b484e3f0be6a8e27d6bb59e7eab3
 ./packages/api-utils/lib/runtime.js 1.9b3 c890d46b04876a2bdebcc9fade057fea2ba0b484e3f0be6a8e27d6bb59e7eab3
 ./packages/api-utils/lib/runtime.js 1.9-dev c890d46b04876a2bdebcc9fade057fea2ba0b484e3f0be6a8e27d6bb59e7eab3
+./packages/api-utils/lib/runtime.js 1.9rc1 c890d46b04876a2bdebcc9fade057fea2ba0b484e3f0be6a8e27d6bb59e7eab3
 ./packages/api-utils/lib/sandbox.js 1.10-dev 5d5fcb3d381de91cf2a208d82f0d84eb353b0dd69daac86ef96cd1aaefa02c75
 ./packages/api-utils/lib/sandbox.js 1.5 5d5fcb3d381de91cf2a208d82f0d84eb353b0dd69daac86ef96cd1aaefa02c75
 ./packages/api-utils/lib/sandbox.js 1.5b1 5d5fcb3d381de91cf2a208d82f0d84eb353b0dd69daac86ef96cd1aaefa02c75
@@ -9906,6 +10040,7 @@
 ./packages/api-utils/lib/sandbox.js 1.9b2 5d5fcb3d381de91cf2a208d82f0d84eb353b0dd69daac86ef96cd1aaefa02c75
 ./packages/api-utils/lib/sandbox.js 1.9b3 5d5fcb3d381de91cf2a208d82f0d84eb353b0dd69daac86ef96cd1aaefa02c75
 ./packages/api-utils/lib/sandbox.js 1.9-dev 5d5fcb3d381de91cf2a208d82f0d84eb353b0dd69daac86ef96cd1aaefa02c75
+./packages/api-utils/lib/sandbox.js 1.9rc1 5d5fcb3d381de91cf2a208d82f0d84eb353b0dd69daac86ef96cd1aaefa02c75
 ./packages/api-utils/lib/securable-module.js 1.0 933d2fd0cc2555f2bd501e2ee10ee70cf819d9559d453e455036e77a17347bf9
 ./packages/api-utils/lib/securable-module.js 1.0b1 66d80776b2e0ba98fa21e5ed5d71a6e08fc45145992cbb5589b442962dd7d11e
 ./packages/api-utils/lib/securable-module.js 1.0b1rc1 66d80776b2e0ba98fa21e5ed5d71a6e08fc45145992cbb5589b442962dd7d11e
@@ -10059,6 +10194,7 @@
 ./packages/api-utils/lib/self.js 1.9b2 57d4cb80b95290aaf9cbee40afc11a2b2e0709197dcdd22e4eb6a4553715d717
 ./packages/api-utils/lib/self.js 1.9b3 57d4cb80b95290aaf9cbee40afc11a2b2e0709197dcdd22e4eb6a4553715d717
 ./packages/api-utils/lib/self!.js 1.9-dev fbddbae729913f692eafdc197a15c3df9067e6a62efdfa89041cefec62cbfefe
+./packages/api-utils/lib/self.js 1.9rc1 57d4cb80b95290aaf9cbee40afc11a2b2e0709197dcdd22e4eb6a4553715d717
 ./packages/api-utils/lib/self-maker.js 1.0 319e086e574216f37a2fa0b723b61632752c5b0cccfc59f40aa248acabca00eb
 ./packages/api-utils/lib/self-maker.js 1.0rc1 319e086e574216f37a2fa0b723b61632752c5b0cccfc59f40aa248acabca00eb
 ./packages/api-utils/lib/self-maker.js 1.0rc2 319e086e574216f37a2fa0b723b61632752c5b0cccfc59f40aa248acabca00eb
@@ -10121,6 +10257,7 @@
 ./packages/api-utils/lib/system/events.js 1.9b2 4784b543a1b284897d10e77ad35110351e66525d0b3b440aceba9453e909d7fc
 ./packages/api-utils/lib/system/events.js 1.9b3 4784b543a1b284897d10e77ad35110351e66525d0b3b440aceba9453e909d7fc
 ./packages/api-utils/lib/system/events.js 1.9-dev 6bdbe64c8152e265072cb7c63465253c631fd5cc19691e03d028bfeca232bc29
+./packages/api-utils/lib/system/events.js 1.9rc1 4784b543a1b284897d10e77ad35110351e66525d0b3b440aceba9453e909d7fc
 ./packages/api-utils/lib/system.js 1.10-dev d72f5fd73f425cf6ee74f60ec5afc51f8f19b77bd5fccf0d14e305fdf07e4d64
 ./packages/api-utils/lib/system.js 1.4.1 7456537c16443d4a8bbe09c3a104fb2742adef5fe53958f525c3eaa56173c146
 ./packages/api-utils/lib/system.js 1.4.2 7456537c16443d4a8bbe09c3a104fb2742adef5fe53958f525c3eaa56173c146
@@ -10169,6 +10306,7 @@
 ./packages/api-utils/lib/system.js 1.9b2 d72f5fd73f425cf6ee74f60ec5afc51f8f19b77bd5fccf0d14e305fdf07e4d64
 ./packages/api-utils/lib/system.js 1.9b3 d72f5fd73f425cf6ee74f60ec5afc51f8f19b77bd5fccf0d14e305fdf07e4d64
 ./packages/api-utils/lib/system.js 1.9-dev 77da3de84feb592f24d2bf326d72e45960ebcc4296f8cb49406048f87da718ea
+./packages/api-utils/lib/system.js 1.9rc1 d72f5fd73f425cf6ee74f60ec5afc51f8f19b77bd5fccf0d14e305fdf07e4d64
 ./packages/api-utils/lib/tab-browser.js 1.0 a41230a4661d1007c74dc82da3d25a80adcd1976f9232ea1762b4e7e74fed35e
 ./packages/api-utils/lib/tab-browser.js 1.0b1 a41230a4661d1007c74dc82da3d25a80adcd1976f9232ea1762b4e7e74fed35e
 ./packages/api-utils/lib/tab-browser.js 1.0b1rc1 a41230a4661d1007c74dc82da3d25a80adcd1976f9232ea1762b4e7e74fed35e
@@ -10260,6 +10398,7 @@
 ./packages/api-utils/lib/tab-browser.js 1.9b2 ca599efd6f11968f6bac90158768762e81f82cd188ea90af108583137c0e2189
 ./packages/api-utils/lib/tab-browser.js 1.9b3 ca599efd6f11968f6bac90158768762e81f82cd188ea90af108583137c0e2189
 ./packages/api-utils/lib/tab-browser.js 1.9-dev ca599efd6f11968f6bac90158768762e81f82cd188ea90af108583137c0e2189
+./packages/api-utils/lib/tab-browser.js 1.9rc1 ca599efd6f11968f6bac90158768762e81f82cd188ea90af108583137c0e2189
 ./packages/api-utils/lib/tabs/events.js 1.0 163e7b0758a0d07fa4dd6b26d50d3085e85e88a1babce6d232a33bf9c9ecc551
 ./packages/api-utils/lib/tabs/events.js 1.0b1 163e7b0758a0d07fa4dd6b26d50d3085e85e88a1babce6d232a33bf9c9ecc551
 ./packages/api-utils/lib/tabs/events.js 1.0b1rc1 163e7b0758a0d07fa4dd6b26d50d3085e85e88a1babce6d232a33bf9c9ecc551
@@ -10351,6 +10490,7 @@
 ./packages/api-utils/lib/tabs/events.js 1.9b2 601f63124ee5fc721827f0bc7d51a0ce285ac20afd954eeb1d5ea2b3ae31c4da
 ./packages/api-utils/lib/tabs/events.js 1.9b3 601f63124ee5fc721827f0bc7d51a0ce285ac20afd954eeb1d5ea2b3ae31c4da
 ./packages/api-utils/lib/tabs/events.js 1.9-dev 601f63124ee5fc721827f0bc7d51a0ce285ac20afd954eeb1d5ea2b3ae31c4da
+./packages/api-utils/lib/tabs/events.js 1.9rc1 601f63124ee5fc721827f0bc7d51a0ce285ac20afd954eeb1d5ea2b3ae31c4da
 ./packages/api-utils/lib/tabs/observer.js 1.0 0f28ec36e0c63acd147f6a4a306b339640a05461df9b3545511c2140c325d449
 ./packages/api-utils/lib/tabs/observer.js 1.0rc1 0f28ec36e0c63acd147f6a4a306b339640a05461df9b3545511c2140c325d449
 ./packages/api-utils/lib/tabs/observer.js 1.0rc2 0f28ec36e0c63acd147f6a4a306b339640a05461df9b3545511c2140c325d449
@@ -10423,6 +10563,7 @@
 ./packages/api-utils/lib/tabs/observer.js 1.9b2 b00783f97b0410b4e09afdb75a88af01527d1007545bbdc2ed85b9e1bd386989
 ./packages/api-utils/lib/tabs/observer.js 1.9b3 b00783f97b0410b4e09afdb75a88af01527d1007545bbdc2ed85b9e1bd386989
 ./packages/api-utils/lib/tabs/observer.js 1.9-dev e21a32cd41cf9dd81010e03013a4525ccbe9382ff71b9659d0e2ecd12931cd17
+./packages/api-utils/lib/tabs/observer.js 1.9rc1 b00783f97b0410b4e09afdb75a88af01527d1007545bbdc2ed85b9e1bd386989
 ./packages/api-utils/lib/tabs/tab.js 1.0b1 df581ee189be5be466024fab61bdc7b87950c971f32efe23067b1418544a1c30
 ./packages/api-utils/lib/tabs/tab.js 1.0b1rc1 bc74b2881ecd8e73bcdf2047effabcf746ff4b81c0e507865c0971ad5dbd4fb4
 ./packages/api-utils/lib/tabs/tab.js 1.0b1rc2 df581ee189be5be466024fab61bdc7b87950c971f32efe23067b1418544a1c30
@@ -10514,6 +10655,7 @@
 ./packages/api-utils/lib/tabs/tab.js 1.9b2 97abe4abb0b3db46074cc34266a6fc6727beedfb8dcd122b7da951daade9bf36
 ./packages/api-utils/lib/tabs/tab.js 1.9b3 97abe4abb0b3db46074cc34266a6fc6727beedfb8dcd122b7da951daade9bf36
 ./packages/api-utils/lib/tabs/tab.js 1.9-dev 97abe4abb0b3db46074cc34266a6fc6727beedfb8dcd122b7da951daade9bf36
+./packages/api-utils/lib/tabs/tab.js 1.9rc1 97abe4abb0b3db46074cc34266a6fc6727beedfb8dcd122b7da951daade9bf36
 ./packages/api-utils/lib/tabs/utils.js 1.0 12f286eca94b0a0eaa118da7e343ade20b8badf03bbe790cd2017facf07d73aa
 ./packages/api-utils/lib/tabs/utils.js 1.0rc1 12f286eca94b0a0eaa118da7e343ade20b8badf03bbe790cd2017facf07d73aa
 ./packages/api-utils/lib/tabs/utils.js 1.0rc2 12f286eca94b0a0eaa118da7e343ade20b8badf03bbe790cd2017facf07d73aa
@@ -10586,6 +10728,7 @@
 ./packages/api-utils/lib/tabs/utils.js 1.9b2 bcb2ce52cddafcef38cfa226e240acce4c9a8281e1639763ff41b33100e137c7
 ./packages/api-utils/lib/tabs/utils.js 1.9b3 bcb2ce52cddafcef38cfa226e240acce4c9a8281e1639763ff41b33100e137c7
 ./packages/api-utils/lib/tabs/utils.js 1.9-dev eac5893db13b5d07a203fd485fe656a13e6c8c647d39442d18e3b095c7870f97
+./packages/api-utils/lib/tabs/utils.js 1.9rc1 bcb2ce52cddafcef38cfa226e240acce4c9a8281e1639763ff41b33100e137c7
 ./packages/api-utils/lib/test/assert.js 1.0 2a35ef22e07860afd0beb692bfcc0fba51e267223701633718b75d62e00a360f
 ./packages/api-utils/lib/test/assert.js 1.0b3 35c87dedaad26f419439eef7f41fdc668df977dd2985b189bb04cb70cace4971
 ./packages/api-utils/lib/test/assert.js 1.0b3rc1 35c87dedaad26f419439eef7f41fdc668df977dd2985b189bb04cb70cace4971
@@ -10670,6 +10813,7 @@
 ./packages/api-utils/lib/test/assert.js 1.9b2 a7ee400b76a428356aff2665665d75b9faef60af9a4690994773f9c2f09601c6
 ./packages/api-utils/lib/test/assert.js 1.9b3 a7ee400b76a428356aff2665665d75b9faef60af9a4690994773f9c2f09601c6
 ./packages/api-utils/lib/test/assert.js 1.9-dev a7ee400b76a428356aff2665665d75b9faef60af9a4690994773f9c2f09601c6
+./packages/api-utils/lib/test/assert.js 1.9rc1 a7ee400b76a428356aff2665665d75b9faef60af9a4690994773f9c2f09601c6
 ./packages/api-utils/lib/test.js 1.0 9f22a022313aabcb0a4fcb08e2f8e806212580167130521efcee0b284df3e741
 ./packages/api-utils/lib/test.js 1.0b3 9f22a022313aabcb0a4fcb08e2f8e806212580167130521efcee0b284df3e741
 ./packages/api-utils/lib/test.js 1.0b3rc1 9f22a022313aabcb0a4fcb08e2f8e806212580167130521efcee0b284df3e741
@@ -10754,6 +10898,7 @@
 ./packages/api-utils/lib/test.js 1.9b2 de47ce217c00d411fda2c13a27185bfa5445b258dcf39e59ca1c0049fed6d044
 ./packages/api-utils/lib/test.js 1.9b3 de47ce217c00d411fda2c13a27185bfa5445b258dcf39e59ca1c0049fed6d044
 ./packages/api-utils/lib/test.js 1.9-dev de47ce217c00d411fda2c13a27185bfa5445b258dcf39e59ca1c0049fed6d044
+./packages/api-utils/lib/test.js 1.9rc1 de47ce217c00d411fda2c13a27185bfa5445b258dcf39e59ca1c0049fed6d044
 ./packages/api-utils/lib/text-streams.js 1.0 aa3ba9bf8fcb0ff1bd6d71d904851c6b658aa0e0b5269fc61e3ed07367699165
 ./packages/api-utils/lib/text-streams.js 1.0b1 aa3ba9bf8fcb0ff1bd6d71d904851c6b658aa0e0b5269fc61e3ed07367699165
 ./packages/api-utils/lib/text-streams.js 1.0b1rc1 aa3ba9bf8fcb0ff1bd6d71d904851c6b658aa0e0b5269fc61e3ed07367699165
@@ -10845,6 +10990,7 @@
 ./packages/api-utils/lib/text-streams.js 1.9b2 1290e60106ce88356cef2f78ee594082a711063351825732037542920a779225
 ./packages/api-utils/lib/text-streams.js 1.9b3 1290e60106ce88356cef2f78ee594082a711063351825732037542920a779225
 ./packages/api-utils/lib/text-streams.js 1.9-dev 1290e60106ce88356cef2f78ee594082a711063351825732037542920a779225
+./packages/api-utils/lib/text-streams.js 1.9rc1 1290e60106ce88356cef2f78ee594082a711063351825732037542920a779225
 ./packages/api-utils/lib/timer-e10s-adapter.js 1.0 a08690ac530902d587e202d97690af8f62087e1a9e4a0fc98ab9707b4fb9cb63
 ./packages/api-utils/lib/timer-e10s-adapter.js 1.0b1 64d3b62adb6c8a12143a06939a13b0feef550144f3268e9a5001b4600b7bdf7a
 ./packages/api-utils/lib/timer-e10s-adapter.js 1.0b1rc1 64d3b62adb6c8a12143a06939a13b0feef550144f3268e9a5001b4600b7bdf7a
@@ -10979,6 +11125,7 @@
 ./packages/api-utils/lib/timer.js 1.9b2 cc4ca39d4570f42755ff8fe3a2da101b0392db30e886db46578b722b4b57cfe0
 ./packages/api-utils/lib/timer.js 1.9b3 cc4ca39d4570f42755ff8fe3a2da101b0392db30e886db46578b722b4b57cfe0
 ./packages/api-utils/lib/timer.js 1.9-dev cc4ca39d4570f42755ff8fe3a2da101b0392db30e886db46578b722b4b57cfe0
+./packages/api-utils/lib/timer.js 1.9rc1 cc4ca39d4570f42755ff8fe3a2da101b0392db30e886db46578b722b4b57cfe0
 ./packages/api-utils/lib/traceback.js 1.0 47857e60c19cefbbec79182a724a0d9ffe51442cc484ff2ebd8e52fb766c4a9f
 ./packages/api-utils/lib/traceback.js 1.0b1 47857e60c19cefbbec79182a724a0d9ffe51442cc484ff2ebd8e52fb766c4a9f
 ./packages/api-utils/lib/traceback.js 1.0b1rc1 47857e60c19cefbbec79182a724a0d9ffe51442cc484ff2ebd8e52fb766c4a9f
@@ -11070,6 +11217,7 @@
 ./packages/api-utils/lib/traceback.js 1.9b2 1eea45d6b1540b46d8ed296b37e9326e55e14715ec3209a0d38d99bf862f0cdd
 ./packages/api-utils/lib/traceback.js 1.9b3 1eea45d6b1540b46d8ed296b37e9326e55e14715ec3209a0d38d99bf862f0cdd
 ./packages/api-utils/lib/traceback.js 1.9-dev 1eea45d6b1540b46d8ed296b37e9326e55e14715ec3209a0d38d99bf862f0cdd
+./packages/api-utils/lib/traceback.js 1.9rc1 1eea45d6b1540b46d8ed296b37e9326e55e14715ec3209a0d38d99bf862f0cdd
 ./packages/api-utils/lib/traits/core.js 1.0 327d31bdb5e20294cd35ffac1ac1a964eb553a89e3d10cdedfb5401d7dac9d98
 ./packages/api-utils/lib/traits/core.js 1.0b1 327d31bdb5e20294cd35ffac1ac1a964eb553a89e3d10cdedfb5401d7dac9d98
 ./packages/api-utils/lib/traits/core.js 1.0b1rc1 327d31bdb5e20294cd35ffac1ac1a964eb553a89e3d10cdedfb5401d7dac9d98
@@ -11161,6 +11309,7 @@
 ./packages/api-utils/lib/traits/core.js 1.9b2 3a89ea0ad6095bd1e318549e622fd9a030373d04d329315a3a182e91c09614c5
 ./packages/api-utils/lib/traits/core.js 1.9b3 3a89ea0ad6095bd1e318549e622fd9a030373d04d329315a3a182e91c09614c5
 ./packages/api-utils/lib/traits/core.js 1.9-dev 3a89ea0ad6095bd1e318549e622fd9a030373d04d329315a3a182e91c09614c5
+./packages/api-utils/lib/traits/core.js 1.9rc1 3a89ea0ad6095bd1e318549e622fd9a030373d04d329315a3a182e91c09614c5
 ./packages/api-utils/lib/traits.js 1.0 0689e903d8dd172cff8fc88f3444d9082ea0909be8188fcfff69385d0813e170
 ./packages/api-utils/lib/traits.js 1.0b1 0689e903d8dd172cff8fc88f3444d9082ea0909be8188fcfff69385d0813e170
 ./packages/api-utils/lib/traits.js 1.0b1rc1 0689e903d8dd172cff8fc88f3444d9082ea0909be8188fcfff69385d0813e170
@@ -11252,6 +11401,7 @@
 ./packages/api-utils/lib/traits.js 1.9b2 b6b6bebf59c46adf01bcb80f8a97aa354b7a6eb912733ae5521097f25bf08fc3
 ./packages/api-utils/lib/traits.js 1.9b3 b6b6bebf59c46adf01bcb80f8a97aa354b7a6eb912733ae5521097f25bf08fc3
 ./packages/api-utils/lib/traits.js 1.9-dev b6b6bebf59c46adf01bcb80f8a97aa354b7a6eb912733ae5521097f25bf08fc3
+./packages/api-utils/lib/traits.js 1.9rc1 b6b6bebf59c46adf01bcb80f8a97aa354b7a6eb912733ae5521097f25bf08fc3
 ./packages/api-utils/lib/type.js 1.0 67d65bc65ae0fb529be45cbfa8dacd918f2ceb7010f0e41ad08c13a1580ef016
 ./packages/api-utils/lib/type.js 1.0b3 0d8ad1fd731a7e254ea631ea31dc479738d59910a0c217f71863eedac8a182a7
 ./packages/api-utils/lib/type.js 1.0b3rc1 0d8ad1fd731a7e254ea631ea31dc479738d59910a0c217f71863eedac8a182a7
@@ -11336,6 +11486,7 @@
 ./packages/api-utils/lib/type.js 1.9b2 4b1b10678b0087004b50bd9c765f9794120c2a23b0ddcc48351da58c9e5603d6
 ./packages/api-utils/lib/type.js 1.9b3 4b1b10678b0087004b50bd9c765f9794120c2a23b0ddcc48351da58c9e5603d6
 ./packages/api-utils/lib/type.js 1.9-dev 4b1b10678b0087004b50bd9c765f9794120c2a23b0ddcc48351da58c9e5603d6
+./packages/api-utils/lib/type.js 1.9rc1 4b1b10678b0087004b50bd9c765f9794120c2a23b0ddcc48351da58c9e5603d6
 ./packages/api-utils/lib/unit-test-finder.js 1.0 7760c777829275d7a63f24c1f3f52079a994c7b139a242b4d350fcee9792702d
 ./packages/api-utils/lib/unit-test-finder.js 1.0b1 ee9c99f2e9f18ec3de555df9cc6c53d4d9d45dc18d477b5c7f61ee16331666ad
 ./packages/api-utils/lib/unit-test-finder.js 1.0b1rc1 ee9c99f2e9f18ec3de555df9cc6c53d4d9d45dc18d477b5c7f61ee16331666ad
@@ -11427,6 +11578,7 @@
 ./packages/api-utils/lib/unit-test-finder.js 1.9b2 c47e40932bbd8fcdd436f6d49d2c48bd94195da766ee2f7be7193ddc82fe7ca0
 ./packages/api-utils/lib/unit-test-finder.js 1.9b3 c47e40932bbd8fcdd436f6d49d2c48bd94195da766ee2f7be7193ddc82fe7ca0
 ./packages/api-utils/lib/unit-test-finder.js 1.9-dev c28da8d5afda4f55de4184f741a94d48cfec267e536186aa6485add795169dd0
+./packages/api-utils/lib/unit-test-finder.js 1.9rc1 c47e40932bbd8fcdd436f6d49d2c48bd94195da766ee2f7be7193ddc82fe7ca0
 ./packages/api-utils/lib/unit-test.js 1.0 96aa9eb2de710dbd7754c145b9924402f471338c12d4d4072239c9c568433378
 ./packages/api-utils/lib/unit-test.js 1.0b1 7e265eec238dd7789aa3b3ad596fa8e08bf9b2cb543d0afa85f5b7203bd525bd
 ./packages/api-utils/lib/unit-test.js 1.0b1rc1 7e265eec238dd7789aa3b3ad596fa8e08bf9b2cb543d0afa85f5b7203bd525bd
@@ -11518,6 +11670,7 @@
 ./packages/api-utils/lib/unit-test.js 1.9b2 ba8f6aef6cc02f89ff49a0db45e1083ef96ef3268180aa32ced23d583a212f18
 ./packages/api-utils/lib/unit-test.js 1.9b3 ba8f6aef6cc02f89ff49a0db45e1083ef96ef3268180aa32ced23d583a212f18
 ./packages/api-utils/lib/unit-test.js 1.9-dev 1e21b22cb138457b1c235fdb7a24ecf5e2d0f58f3f59e94fff98c96b7831df44
+./packages/api-utils/lib/unit-test.js 1.9rc1 ba8f6aef6cc02f89ff49a0db45e1083ef96ef3268180aa32ced23d583a212f18
 ./packages/api-utils/lib/unload.js 1.0 072706cf3880a5b2030ff47fa0f186d2d2919c65719154c46d15840ec198897f
 ./packages/api-utils/lib/unload.js 1.0b1 604f33e2cdc44bb89c6e344b8536bd1160cce7e8938c8db23775c05d9d88bad6
 ./packages/api-utils/lib/unload.js 1.0b1rc1 604f33e2cdc44bb89c6e344b8536bd1160cce7e8938c8db23775c05d9d88bad6
@@ -11609,6 +11762,7 @@
 ./packages/api-utils/lib/unload.js 1.9b2 b973f42e953989e84a4919f20d29e2ca742e71b9c857c173e325d8e99ea69471
 ./packages/api-utils/lib/unload.js 1.9b3 b973f42e953989e84a4919f20d29e2ca742e71b9c857c173e325d8e99ea69471
 ./packages/api-utils/lib/unload.js 1.9-dev 2432543d473bd53c72b0b5e4acb6de9fb3f34b5297fc900c3d7faa3bc31ffd88
+./packages/api-utils/lib/unload.js 1.9rc1 b973f42e953989e84a4919f20d29e2ca742e71b9c857c173e325d8e99ea69471
 ./packages/api-utils/lib/url-e10s-adapter.js 1.0 0a5f769b33424ca3c1c306c721ccb490a267d0ac843ae3bb0afc73a9ce62db73
 ./packages/api-utils/lib/url-e10s-adapter.js 1.0b2 0a5f769b33424ca3c1c306c721ccb490a267d0ac843ae3bb0afc73a9ce62db73
 ./packages/api-utils/lib/url-e10s-adapter.js 1.0b2rc1 0a5f769b33424ca3c1c306c721ccb490a267d0ac843ae3bb0afc73a9ce62db73
@@ -11738,6 +11892,7 @@
 ./packages/api-utils/lib/url.js 1.9b2 5c88a2a8337dcc785ff3e6d3f10d7e83dcd6c39b7cb911618379a256443facbf
 ./packages/api-utils/lib/url.js 1.9b3 5c88a2a8337dcc785ff3e6d3f10d7e83dcd6c39b7cb911618379a256443facbf
 ./packages/api-utils/lib/url.js 1.9-dev 1d7259d85252f34bc0a04adfae30cda97a2e7d49b2070087e9da72b746348ce2
+./packages/api-utils/lib/url.js 1.9rc1 5c88a2a8337dcc785ff3e6d3f10d7e83dcd6c39b7cb911618379a256443facbf
 ./packages/api-utils/lib/utils/data.js 1.0 2ac7da43a127ef1e4a5ee1f3c031f3b4e1d6f4d0a36bc31c1d5ae283c80ad95f
 ./packages/api-utils/lib/utils/data.js 1.0b1 2ac7da43a127ef1e4a5ee1f3c031f3b4e1d6f4d0a36bc31c1d5ae283c80ad95f
 ./packages/api-utils/lib/utils/data.js 1.0b1rc1 2ac7da43a127ef1e4a5ee1f3c031f3b4e1d6f4d0a36bc31c1d5ae283c80ad95f
@@ -11829,6 +11984,7 @@
 ./packages/api-utils/lib/utils/data.js 1.9b2 b59000d442138a2b2e15be6e0d606c09ec81b93c0e6dbc56002d92e1c251635a
 ./packages/api-utils/lib/utils/data.js 1.9b3 b59000d442138a2b2e15be6e0d606c09ec81b93c0e6dbc56002d92e1c251635a
 ./packages/api-utils/lib/utils/data.js 1.9-dev b81a92a26b0f23e020bc873cab8af18062107b3a54a941dae3968e2cdf07b6dd
+./packages/api-utils/lib/utils/data.js 1.9rc1 b59000d442138a2b2e15be6e0d606c09ec81b93c0e6dbc56002d92e1c251635a
 ./packages/api-utils/lib/utils/function.js 1.0 9ef84f8a1231c68f7aa5af2bc902e1bd5ec0c28b97e53310c40974903b0795fd
 ./packages/api-utils/lib/utils/function.js 1.0b1 9ef84f8a1231c68f7aa5af2bc902e1bd5ec0c28b97e53310c40974903b0795fd
 ./packages/api-utils/lib/utils/function.js 1.0b1rc1 9ef84f8a1231c68f7aa5af2bc902e1bd5ec0c28b97e53310c40974903b0795fd
@@ -11927,6 +12083,7 @@
 ./packages/api-utils/lib/utils/object.js 1.9b2 021787f0d120106d31e01bd10a01f03d6247804ea832faced3bf42bd67a8b48a
 ./packages/api-utils/lib/utils/object.js 1.9b3 021787f0d120106d31e01bd10a01f03d6247804ea832faced3bf42bd67a8b48a
 ./packages/api-utils/lib/utils/object.js 1.9-dev 021787f0d120106d31e01bd10a01f03d6247804ea832faced3bf42bd67a8b48a
+./packages/api-utils/lib/utils/object.js 1.9rc1 021787f0d120106d31e01bd10a01f03d6247804ea832faced3bf42bd67a8b48a
 ./packages/api-utils/lib/utils/registry.js 1.0 a003bf85f9c75f97c75ac9730c4164bd4a7baf610530472cd95a9f3e520f07b0
 ./packages/api-utils/lib/utils/registry.js 1.0b1 0a103b720994006069b814f35cb720703638d965f3cda2633d46dcbd754efa3b
 ./packages/api-utils/lib/utils/registry.js 1.0b1rc1 0a103b720994006069b814f35cb720703638d965f3cda2633d46dcbd754efa3b
@@ -12018,6 +12175,7 @@
 ./packages/api-utils/lib/utils/registry.js 1.9b2 cc3ace2ff3d695e838358221518afa8cb5ea80bac362e75c737bf27e0d93e405
 ./packages/api-utils/lib/utils/registry.js 1.9b3 cc3ace2ff3d695e838358221518afa8cb5ea80bac362e75c737bf27e0d93e405
 ./packages/api-utils/lib/utils/registry.js 1.9-dev cc3ace2ff3d695e838358221518afa8cb5ea80bac362e75c737bf27e0d93e405
+./packages/api-utils/lib/utils/registry.js 1.9rc1 cc3ace2ff3d695e838358221518afa8cb5ea80bac362e75c737bf27e0d93e405
 ./packages/api-utils/lib/utils/thumbnail.js 1.0 a8cd4d1e6d90fcd992fec3edd092b6a92c4df89693e9a46e11d8b67d4743f961
 ./packages/api-utils/lib/utils/thumbnail.js 1.0b1 a8cd4d1e6d90fcd992fec3edd092b6a92c4df89693e9a46e11d8b67d4743f961
 ./packages/api-utils/lib/utils/thumbnail.js 1.0b1rc1 a8cd4d1e6d90fcd992fec3edd092b6a92c4df89693e9a46e11d8b67d4743f961
@@ -12109,6 +12267,7 @@
 ./packages/api-utils/lib/utils/thumbnail.js 1.9b2 c4026174e3c2ee56ef1a7cc85fe6736db4f3de4249c9c9fb2e896b4d8aa9fec2
 ./packages/api-utils/lib/utils/thumbnail.js 1.9b3 c4026174e3c2ee56ef1a7cc85fe6736db4f3de4249c9c9fb2e896b4d8aa9fec2
 ./packages/api-utils/lib/utils/thumbnail.js 1.9-dev c4026174e3c2ee56ef1a7cc85fe6736db4f3de4249c9c9fb2e896b4d8aa9fec2
+./packages/api-utils/lib/utils/thumbnail.js 1.9rc1 c4026174e3c2ee56ef1a7cc85fe6736db4f3de4249c9c9fb2e896b4d8aa9fec2
 ./packages/api-utils/lib/uuid.js 1.10-dev f0dee5801e578994f6c69db12713062a103c380ed55aa0632a1f02c14a9d2a32
 ./packages/api-utils/lib/uuid.js 1.6.1 f0dee5801e578994f6c69db12713062a103c380ed55aa0632a1f02c14a9d2a32
 ./packages/api-utils/lib/uuid.js 1.6.1rc1 f0dee5801e578994f6c69db12713062a103c380ed55aa0632a1f02c14a9d2a32
@@ -12137,6 +12296,7 @@
 ./packages/api-utils/lib/uuid.js 1.9b2 f0dee5801e578994f6c69db12713062a103c380ed55aa0632a1f02c14a9d2a32
 ./packages/api-utils/lib/uuid.js 1.9b3 f0dee5801e578994f6c69db12713062a103c380ed55aa0632a1f02c14a9d2a32
 ./packages/api-utils/lib/uuid.js 1.9-dev f0dee5801e578994f6c69db12713062a103c380ed55aa0632a1f02c14a9d2a32
+./packages/api-utils/lib/uuid.js 1.9rc1 f0dee5801e578994f6c69db12713062a103c380ed55aa0632a1f02c14a9d2a32
 ./packages/api-utils/lib/windows/dom.js 1.0 481073a676547a612878b43e87c33ce28db03b24e2674484046cd6b626fc69a9
 ./packages/api-utils/lib/windows/dom.js 1.0b1 481073a676547a612878b43e87c33ce28db03b24e2674484046cd6b626fc69a9
 ./packages/api-utils/lib/windows/dom.js 1.0b1rc1 481073a676547a612878b43e87c33ce28db03b24e2674484046cd6b626fc69a9
@@ -12228,6 +12388,7 @@
 ./packages/api-utils/lib/windows/dom.js 1.9b2 eaa2464f4e5aeed9f3d4e068036073ec4a2a4848566e71f31057956350c38ba2
 ./packages/api-utils/lib/windows/dom.js 1.9b3 eaa2464f4e5aeed9f3d4e068036073ec4a2a4848566e71f31057956350c38ba2
 ./packages/api-utils/lib/windows/dom.js 1.9-dev eaa2464f4e5aeed9f3d4e068036073ec4a2a4848566e71f31057956350c38ba2
+./packages/api-utils/lib/windows/dom.js 1.9rc1 eaa2464f4e5aeed9f3d4e068036073ec4a2a4848566e71f31057956350c38ba2
 ./packages/api-utils/lib/windows/loader.js 1.0 28f7b3e1242cb1569032d1e11b229efd27728ff4098481fb52dae70b43978f23
 ./packages/api-utils/lib/windows/loader.js 1.0b1 28f7b3e1242cb1569032d1e11b229efd27728ff4098481fb52dae70b43978f23
 ./packages/api-utils/lib/windows/loader.js 1.0b1rc1 28f7b3e1242cb1569032d1e11b229efd27728ff4098481fb52dae70b43978f23
@@ -12319,6 +12480,7 @@
 ./packages/api-utils/lib/windows/loader.js 1.9b2 efd6ed41deec689db50dc09024fdd2d8ddcb8338f53b65a25447f2a38fa78c85
 ./packages/api-utils/lib/windows/loader.js 1.9b3 efd6ed41deec689db50dc09024fdd2d8ddcb8338f53b65a25447f2a38fa78c85
 ./packages/api-utils/lib/windows/loader.js 1.9-dev efd6ed41deec689db50dc09024fdd2d8ddcb8338f53b65a25447f2a38fa78c85
+./packages/api-utils/lib/windows/loader.js 1.9rc1 efd6ed41deec689db50dc09024fdd2d8ddcb8338f53b65a25447f2a38fa78c85
 ./packages/api-utils/lib/windows/observer.js 1.0 01a10eea6b835e513ad86032535135a0e8753c9f23af2ad03936ed36ebc3adff
 ./packages/api-utils/lib/windows/observer.js 1.0b5 4f89af9b9e76b417e8c69db67f107ceee4cacfa81c3422e9d0e75abed9715aef
 ./packages/api-utils/lib/windows/observer.js 1.0b5rc1 4f89af9b9e76b417e8c69db67f107ceee4cacfa81c3422e9d0e75abed9715aef
@@ -12394,6 +12556,7 @@
 ./packages/api-utils/lib/windows/observer.js 1.9b2 4d72a1ba896960fba2742863aaa62b04de11a84eb7b321196be884ebfa7a40cc
 ./packages/api-utils/lib/windows/observer.js 1.9b3 4d72a1ba896960fba2742863aaa62b04de11a84eb7b321196be884ebfa7a40cc
 ./packages/api-utils/lib/windows/observer.js 1.9-dev 4d72a1ba896960fba2742863aaa62b04de11a84eb7b321196be884ebfa7a40cc
+./packages/api-utils/lib/windows/observer.js 1.9rc1 4d72a1ba896960fba2742863aaa62b04de11a84eb7b321196be884ebfa7a40cc
 ./packages/api-utils/lib/windows/tabs.js 1.0 935a16758ccdc3d0a46f255e2b7f24cd4d3f97a91f5cb0336bd5a01a0ce95843
 ./packages/api-utils/lib/windows/tabs.js 1.0b1 56afebec3423d05e5f7767bf6b2e32607bb24411a46fa29c3c486c696a17f0f6
 ./packages/api-utils/lib/windows/tabs.js 1.0b1rc1 56afebec3423d05e5f7767bf6b2e32607bb24411a46fa29c3c486c696a17f0f6
@@ -12485,6 +12648,7 @@
 ./packages/api-utils/lib/windows/tabs.js 1.9b2 2a5b7cad67dd079a05c1ad16e614c2998f60232c74c76200018955d51fcf47be
 ./packages/api-utils/lib/windows/tabs.js 1.9b3 2a5b7cad67dd079a05c1ad16e614c2998f60232c74c76200018955d51fcf47be
 ./packages/api-utils/lib/windows/tabs.js 1.9-dev 2a5b7cad67dd079a05c1ad16e614c2998f60232c74c76200018955d51fcf47be
+./packages/api-utils/lib/windows/tabs.js 1.9rc1 2a5b7cad67dd079a05c1ad16e614c2998f60232c74c76200018955d51fcf47be
 ./packages/api-utils/lib/window-utils.js 1.0b1 7df67366cca8658f66ea269b927015132ab8e4ebda88df3dd5e65a13a30f17b6
 ./packages/api-utils/lib/window-utils.js 1.0b1rc1 7df67366cca8658f66ea269b927015132ab8e4ebda88df3dd5e65a13a30f17b6
 ./packages/api-utils/lib/window-utils.js 1.0b1rc2 7df67366cca8658f66ea269b927015132ab8e4ebda88df3dd5e65a13a30f17b6
@@ -12596,6 +12760,8 @@
 ./packages/api-utils/lib/window/utils.js 1.9b3 d054c083e0affd6a5633da318d0761b61906bb5777b7eebfec004bb0e398ace1
 ./packages/api-utils/lib/window/utils.js 1.9-dev 8f55e9bbb2294d79162b41a811378b443723c60b9127d4085a7c71d9afac8ae4
 ./packages/api-utils/lib/window-utils.js 1.9-dev 9cb53ff91b455a0796a3f638f8efc9cdffc83f925c8ee21a611ed7d11c36fbff
+./packages/api-utils/lib/window-utils.js 1.9rc1 4249792ddfacc51f767af4bfef48062cd7faa09e01473b563c022aad01e2815a
+./packages/api-utils/lib/window/utils.js 1.9rc1 d054c083e0affd6a5633da318d0761b61906bb5777b7eebfec004bb0e398ace1
 ./packages/api-utils/lib/xhr.js 1.0 821dd0b9f22f91cc930c59f06237c0bf9e83b0076bd59f23473f7582fd385c23
 ./packages/api-utils/lib/xhr.js 1.0b1 821dd0b9f22f91cc930c59f06237c0bf9e83b0076bd59f23473f7582fd385c23
 ./packages/api-utils/lib/xhr.js 1.0b1rc1 821dd0b9f22f91cc930c59f06237c0bf9e83b0076bd59f23473f7582fd385c23
@@ -12687,6 +12853,7 @@
 ./packages/api-utils/lib/xhr.js 1.9b2 84be6976f23c885e91b236fb9b494875b73216c66393a78f0b771404dd3c9cbb
 ./packages/api-utils/lib/xhr.js 1.9b3 84be6976f23c885e91b236fb9b494875b73216c66393a78f0b771404dd3c9cbb
 ./packages/api-utils/lib/xhr.js 1.9-dev 84be6976f23c885e91b236fb9b494875b73216c66393a78f0b771404dd3c9cbb
+./packages/api-utils/lib/xhr.js 1.9rc1 84be6976f23c885e91b236fb9b494875b73216c66393a78f0b771404dd3c9cbb
 ./packages/api-utils/lib/xpcom.js 1.0 385239296ad28a25f595ace1627721e948cbfe91e956941b19f963eabd3e45f8
 ./packages/api-utils/lib/xpcom.js 1.0b1 464f1b5d1388b98966b67614ffb96a9edb7592a2d3756084623bfc6a56b852b2
 ./packages/api-utils/lib/xpcom.js 1.0b1rc1 464f1b5d1388b98966b67614ffb96a9edb7592a2d3756084623bfc6a56b852b2
@@ -12778,6 +12945,7 @@
 ./packages/api-utils/lib/xpcom.js 1.9b2 3b31a0529b0cd0171cea5938b73ca28a09d217e6c7d6765606513facbc6cae94
 ./packages/api-utils/lib/xpcom.js 1.9b3 3b31a0529b0cd0171cea5938b73ca28a09d217e6c7d6765606513facbc6cae94
 ./packages/api-utils/lib/xpcom.js 1.9-dev 3b31a0529b0cd0171cea5938b73ca28a09d217e6c7d6765606513facbc6cae94
+./packages/api-utils/lib/xpcom.js 1.9rc1 3b31a0529b0cd0171cea5938b73ca28a09d217e6c7d6765606513facbc6cae94
 ./packages/api-utils/lib/xul-app.js 1.0b1 c4929c0d714aac061560c110e6344efcaa9107d77c5929114282ea5914cee010
 ./packages/api-utils/lib/xul-app.js 1.0b1rc1 c4929c0d714aac061560c110e6344efcaa9107d77c5929114282ea5914cee010
 ./packages/api-utils/lib/xul-app.js 1.0b1rc2 c4929c0d714aac061560c110e6344efcaa9107d77c5929114282ea5914cee010
@@ -12869,6 +13037,7 @@
 ./packages/api-utils/lib/xul-app.js 1.9b2 712b929399b525bf49eb95af4c2f91a5500d0c0a739ff87a7c5acf333dada3e9
 ./packages/api-utils/lib/xul-app.js 1.9b3 712b929399b525bf49eb95af4c2f91a5500d0c0a739ff87a7c5acf333dada3e9
 ./packages/api-utils/lib/xul-app.js 1.9-dev 712b929399b525bf49eb95af4c2f91a5500d0c0a739ff87a7c5acf333dada3e9
+./packages/api-utils/lib/xul-app.js 1.9rc1 712b929399b525bf49eb95af4c2f91a5500d0c0a739ff87a7c5acf333dada3e9
 ./packages/api-utils/tests/commonjs-test-adapter/asserts.js 1.0b3 b856f91812d5b23cb76205f0009cf5d8f9847bd6a296458e7eb6700770b8111c
 ./packages/api-utils/tests/commonjs-test-adapter/asserts.js 1.0b3rc1 b856f91812d5b23cb76205f0009cf5d8f9847bd6a296458e7eb6700770b8111c
 ./packages/api-utils/tests/commonjs-test-adapter/asserts.js 1.0b3rc2 b856f91812d5b23cb76205f0009cf5d8f9847bd6a296458e7eb6700770b8111c
@@ -12953,6 +13122,7 @@
 ./packages/api-utils/tests/commonjs-test-adapter/asserts.js 1.9b2 cbed71410a3445542ff6e697741fda94b456ee2de1edf80b3e48190c25b16660
 ./packages/api-utils/tests/commonjs-test-adapter/asserts.js 1.9b3 cbed71410a3445542ff6e697741fda94b456ee2de1edf80b3e48190c25b16660
 ./packages/api-utils/tests/commonjs-test-adapter/asserts.js 1.9-dev cbed71410a3445542ff6e697741fda94b456ee2de1edf80b3e48190c25b16660
+./packages/api-utils/tests/commonjs-test-adapter/asserts.js 1.9rc1 cbed71410a3445542ff6e697741fda94b456ee2de1edf80b3e48190c25b16660
 ./packages/api-utils/tests/e10s-samples/adapter-only-client.js 1.0b1 ff0b0027986dc67807572cdb62bd35caa9aaee464d1b922eb00b689361d07000
 ./packages/api-utils/tests/e10s-samples/adapter-only-client.js 1.0b1rc1 ff0b0027986dc67807572cdb62bd35caa9aaee464d1b922eb00b689361d07000
 ./packages/api-utils/tests/e10s-samples/adapter-only-client.js 1.0b1rc2 ff0b0027986dc67807572cdb62bd35caa9aaee464d1b922eb00b689361d07000
@@ -13588,6 +13758,11 @@
 ./packages/api-utils/tests/fixtures/es5.js 1.9b2 bf6fec822073e5b0a85342c759f91e0d057a316af5427eb0d8fee70c9a6da3a4
 ./packages/api-utils/tests/fixtures/es5.js 1.9b3 bf6fec822073e5b0a85342c759f91e0d057a316af5427eb0d8fee70c9a6da3a4
 ./packages/api-utils/tests/fixtures/es5.js 1.9-dev bf6fec822073e5b0a85342c759f91e0d057a316af5427eb0d8fee70c9a6da3a4
+./packages/api-utils/tests/fixtures/es5.js 1.9rc1 bf6fec822073e5b0a85342c759f91e0d057a316af5427eb0d8fee70c9a6da3a4
+./packages/api-utils/tests/fixtures/loader/cycles/a.js 1.9rc1 1acb7550713a6ae4e595b0b4504263e4c2544825b9237d7188c90be47fa3d8a7
+./packages/api-utils/tests/fixtures/loader/cycles/b.js 1.9rc1 106edbfa4312a1a43c6f56e8a27e18c50db49b141524dc304f2291fecb8aa295
+./packages/api-utils/tests/fixtures/loader/cycles/c.js 1.9rc1 c39fa4dec856ea6e36de23a913865f0b6c53245fa3d1528e2aa1ee71ab7890d5
+./packages/api-utils/tests/fixtures/loader/cycles/main.js 1.9rc1 9433def78ff30d569b3ac57643456d2416fdddf27cb84f47393806a793807c0e
 ./packages/api-utils/tests/fixtures/sandbox-complex-character.js 1.10-dev 44f5925c64a3f0cf2a3a6961598e2650e1c8fae15743ae72b65a82e08ef8412e
 ./packages/api-utils/tests/fixtures/sandbox-complex-character.js 1.5 44f5925c64a3f0cf2a3a6961598e2650e1c8fae15743ae72b65a82e08ef8412e
 ./packages/api-utils/tests/fixtures/sandbox-complex-character.js 1.5b1 44f5925c64a3f0cf2a3a6961598e2650e1c8fae15743ae72b65a82e08ef8412e
@@ -13623,6 +13798,7 @@
 ./packages/api-utils/tests/fixtures/sandbox-complex-character.js 1.9b2 44f5925c64a3f0cf2a3a6961598e2650e1c8fae15743ae72b65a82e08ef8412e
 ./packages/api-utils/tests/fixtures/sandbox-complex-character.js 1.9b3 44f5925c64a3f0cf2a3a6961598e2650e1c8fae15743ae72b65a82e08ef8412e
 ./packages/api-utils/tests/fixtures/sandbox-complex-character.js 1.9-dev 44f5925c64a3f0cf2a3a6961598e2650e1c8fae15743ae72b65a82e08ef8412e
+./packages/api-utils/tests/fixtures/sandbox-complex-character.js 1.9rc1 44f5925c64a3f0cf2a3a6961598e2650e1c8fae15743ae72b65a82e08ef8412e
 ./packages/api-utils/tests/fixtures/sandbox-normal.js 1.10-dev ac9399679c392278b73bcbed0931139c36a0ed7f160d4a71173e595b6a38cfdd
 ./packages/api-utils/tests/fixtures/sandbox-normal.js 1.5 ac9399679c392278b73bcbed0931139c36a0ed7f160d4a71173e595b6a38cfdd
 ./packages/api-utils/tests/fixtures/sandbox-normal.js 1.5b1 ac9399679c392278b73bcbed0931139c36a0ed7f160d4a71173e595b6a38cfdd
@@ -13658,6 +13834,7 @@
 ./packages/api-utils/tests/fixtures/sandbox-normal.js 1.9b2 ac9399679c392278b73bcbed0931139c36a0ed7f160d4a71173e595b6a38cfdd
 ./packages/api-utils/tests/fixtures/sandbox-normal.js 1.9b3 ac9399679c392278b73bcbed0931139c36a0ed7f160d4a71173e595b6a38cfdd
 ./packages/api-utils/tests/fixtures/sandbox-normal.js 1.9-dev ac9399679c392278b73bcbed0931139c36a0ed7f160d4a71173e595b6a38cfdd
+./packages/api-utils/tests/fixtures/sandbox-normal.js 1.9rc1 ac9399679c392278b73bcbed0931139c36a0ed7f160d4a71173e595b6a38cfdd
 ./packages/api-utils/tests/helpers.js 1.4.1 b16732d393c3cb494e63462ea2a72529a7c3fa63041a61e054e06e7328558f9c
 ./packages/api-utils/tests/helpers.js 1.4.2 b16732d393c3cb494e63462ea2a72529a7c3fa63041a61e054e06e7328558f9c
 ./packages/api-utils/tests/helpers.js 1.4.3 b16732d393c3cb494e63462ea2a72529a7c3fa63041a61e054e06e7328558f9c
@@ -15632,6 +15809,7 @@
 ./packages/api-utils/tests/loader/fixture.js 1.9b2 17f70c97806d3631d5a8760a7ebfe55d29ebfda52096633be51952028f246c77
 ./packages/api-utils/tests/loader/fixture.js 1.9b3 17f70c97806d3631d5a8760a7ebfe55d29ebfda52096633be51952028f246c77
 ./packages/api-utils/tests/loader/fixture.js 1.9-dev 17f70c97806d3631d5a8760a7ebfe55d29ebfda52096633be51952028f246c77
+./packages/api-utils/tests/loader/fixture.js 1.9rc1 17f70c97806d3631d5a8760a7ebfe55d29ebfda52096633be51952028f246c77
 ./packages/api-utils/tests/modules/add.js 1.0b2 b34f95749766d45c7af6dec3b246d94ad69d3ab072dd4b4b6246f08750c5dfde
 ./packages/api-utils/tests/modules/add.js 1.0b2rc1 b34f95749766d45c7af6dec3b246d94ad69d3ab072dd4b4b6246f08750c5dfde
 ./packages/api-utils/tests/modules/add.js 1.0 b34f95749766d45c7af6dec3b246d94ad69d3ab072dd4b4b6246f08750c5dfde
@@ -15718,6 +15896,7 @@
 ./packages/api-utils/tests/modules/add.js 1.9b2 90e48edc6bd51a89dee5e7deae8e51eafb56a42939eb4baeac8334ecfc7ec8bd
 ./packages/api-utils/tests/modules/add.js 1.9b3 90e48edc6bd51a89dee5e7deae8e51eafb56a42939eb4baeac8334ecfc7ec8bd
 ./packages/api-utils/tests/modules/add.js 1.9-dev 90e48edc6bd51a89dee5e7deae8e51eafb56a42939eb4baeac8334ecfc7ec8bd
+./packages/api-utils/tests/modules/add.js 1.9rc1 90e48edc6bd51a89dee5e7deae8e51eafb56a42939eb4baeac8334ecfc7ec8bd
 ./packages/api-utils/tests/modules/async1.js 1.0 16b5f23a68766ff30fa9d6f6637da678296df327c4b1a30a39671038b8261999
 ./packages/api-utils/tests/modules/async1.js 1.0b2 16b5f23a68766ff30fa9d6f6637da678296df327c4b1a30a39671038b8261999
 ./packages/api-utils/tests/modules/async1.js 1.0b2rc1 16b5f23a68766ff30fa9d6f6637da678296df327c4b1a30a39671038b8261999
@@ -15804,6 +15983,7 @@
 ./packages/api-utils/tests/modules/async1.js 1.9b2 745adf0966debbb411958bb5c92c4a3b1f8c2104b3847c583db9910096add757
 ./packages/api-utils/tests/modules/async1.js 1.9b3 745adf0966debbb411958bb5c92c4a3b1f8c2104b3847c583db9910096add757
 ./packages/api-utils/tests/modules/async1.js 1.9-dev 745adf0966debbb411958bb5c92c4a3b1f8c2104b3847c583db9910096add757
+./packages/api-utils/tests/modules/async1.js 1.9rc1 745adf0966debbb411958bb5c92c4a3b1f8c2104b3847c583db9910096add757
 ./packages/api-utils/tests/modules/async2.js 1.0 8c8f095664c0b7fec2f321f222a65ec3e534f325787a5753ad8fd6a5cd5f5ab8
 ./packages/api-utils/tests/modules/async2.js 1.0b2 8c8f095664c0b7fec2f321f222a65ec3e534f325787a5753ad8fd6a5cd5f5ab8
 ./packages/api-utils/tests/modules/async2.js 1.0b2rc1 8c8f095664c0b7fec2f321f222a65ec3e534f325787a5753ad8fd6a5cd5f5ab8
@@ -15890,6 +16070,7 @@
 ./packages/api-utils/tests/modules/async2.js 1.9b2 43a0d8d1a6ff50e087742be5e2e5650ac4e90df326557dd66f044a8dcd241a16
 ./packages/api-utils/tests/modules/async2.js 1.9b3 43a0d8d1a6ff50e087742be5e2e5650ac4e90df326557dd66f044a8dcd241a16
 ./packages/api-utils/tests/modules/async2.js 1.9-dev 43a0d8d1a6ff50e087742be5e2e5650ac4e90df326557dd66f044a8dcd241a16
+./packages/api-utils/tests/modules/async2.js 1.9rc1 43a0d8d1a6ff50e087742be5e2e5650ac4e90df326557dd66f044a8dcd241a16
 ./packages/api-utils/tests/modules/badExportAndReturn.js 1.0 98e0e156498d906e38473c75718311d79c9679250e25371b01a3fecf89804096
 ./packages/api-utils/tests/modules/badExportAndReturn.js 1.0b2 98e0e156498d906e38473c75718311d79c9679250e25371b01a3fecf89804096
 ./packages/api-utils/tests/modules/badExportAndReturn.js 1.0b2rc1 98e0e156498d906e38473c75718311d79c9679250e25371b01a3fecf89804096
@@ -15976,6 +16157,7 @@
 ./packages/api-utils/tests/modules/badExportAndReturn.js 1.9b2 37a771ba17e328a428770ac38ee0547856feaa31c2b9594bd556ca21d8e4609c
 ./packages/api-utils/tests/modules/badExportAndReturn.js 1.9b3 37a771ba17e328a428770ac38ee0547856feaa31c2b9594bd556ca21d8e4609c
 ./packages/api-utils/tests/modules/badExportAndReturn.js 1.9-dev 37a771ba17e328a428770ac38ee0547856feaa31c2b9594bd556ca21d8e4609c
+./packages/api-utils/tests/modules/badExportAndReturn.js 1.9rc1 37a771ba17e328a428770ac38ee0547856feaa31c2b9594bd556ca21d8e4609c
 ./packages/api-utils/tests/modules/badFirst.js 1.0 37cdd2aacb22515cb0d2cd899576fd1eb4f990ae3bf37278a4444fa8bae4928a
 ./packages/api-utils/tests/modules/badFirst.js 1.0b2 37cdd2aacb22515cb0d2cd899576fd1eb4f990ae3bf37278a4444fa8bae4928a
 ./packages/api-utils/tests/modules/badFirst.js 1.0b2rc1 37cdd2aacb22515cb0d2cd899576fd1eb4f990ae3bf37278a4444fa8bae4928a
@@ -16062,6 +16244,7 @@
 ./packages/api-utils/tests/modules/badFirst.js 1.9b2 024492cc7c039897bab20250aa1aee15eda07b7246ef3adebc05d38e00184cb5
 ./packages/api-utils/tests/modules/badFirst.js 1.9b3 024492cc7c039897bab20250aa1aee15eda07b7246ef3adebc05d38e00184cb5
 ./packages/api-utils/tests/modules/badFirst.js 1.9-dev 024492cc7c039897bab20250aa1aee15eda07b7246ef3adebc05d38e00184cb5
+./packages/api-utils/tests/modules/badFirst.js 1.9rc1 024492cc7c039897bab20250aa1aee15eda07b7246ef3adebc05d38e00184cb5
 ./packages/api-utils/tests/modules/badSecond.js 1.0b2 f727923732d0f0eba6358662b527a5798b89510a32d24bc5ed86313a6dfaec2e
 ./packages/api-utils/tests/modules/badSecond.js 1.0b2rc1 f727923732d0f0eba6358662b527a5798b89510a32d24bc5ed86313a6dfaec2e
 ./packages/api-utils/tests/modules/badSecond.js 1.0b3 f727923732d0f0eba6358662b527a5798b89510a32d24bc5ed86313a6dfaec2e
@@ -16148,6 +16331,7 @@
 ./packages/api-utils/tests/modules/badSecond.js 1.9b2 e1d27f05503f5f5899ac880c6bfdb6f129d9765c95aa68d9a030ae1b75a58496
 ./packages/api-utils/tests/modules/badSecond.js 1.9b3 e1d27f05503f5f5899ac880c6bfdb6f129d9765c95aa68d9a030ae1b75a58496
 ./packages/api-utils/tests/modules/badSecond.js 1.9-dev e1d27f05503f5f5899ac880c6bfdb6f129d9765c95aa68d9a030ae1b75a58496
+./packages/api-utils/tests/modules/badSecond.js 1.9rc1 e1d27f05503f5f5899ac880c6bfdb6f129d9765c95aa68d9a030ae1b75a58496
 ./packages/api-utils/tests/modules/blue.js 1.0b2 d9600a9d4b32080e4cf923efccd08f5b9abcea27da2d4785b937bcf01e6e2f0f
 ./packages/api-utils/tests/modules/blue.js 1.0b2rc1 d9600a9d4b32080e4cf923efccd08f5b9abcea27da2d4785b937bcf01e6e2f0f
 ./packages/api-utils/tests/modules/blue.js 1.0b3 d9600a9d4b32080e4cf923efccd08f5b9abcea27da2d4785b937bcf01e6e2f0f
@@ -16234,6 +16418,7 @@
 ./packages/api-utils/tests/modules/blue.js 1.9b2 377b666009ddc80f4ba59da0db79732eec62fcfdce29fba7ed873e4397181b2b
 ./packages/api-utils/tests/modules/blue.js 1.9b3 377b666009ddc80f4ba59da0db79732eec62fcfdce29fba7ed873e4397181b2b
 ./packages/api-utils/tests/modules/blue.js 1.9-dev 377b666009ddc80f4ba59da0db79732eec62fcfdce29fba7ed873e4397181b2b
+./packages/api-utils/tests/modules/blue.js 1.9rc1 377b666009ddc80f4ba59da0db79732eec62fcfdce29fba7ed873e4397181b2b
 ./packages/api-utils/tests/modules/castor.js 1.0 269971c34fb91fd55ce9d53c37a4f46b7ddd471d9739ccd2b67a140d5a2476f4
 ./packages/api-utils/tests/modules/castor.js 1.0b2 269971c34fb91fd55ce9d53c37a4f46b7ddd471d9739ccd2b67a140d5a2476f4
 ./packages/api-utils/tests/modules/castor.js 1.0b2rc1 269971c34fb91fd55ce9d53c37a4f46b7ddd471d9739ccd2b67a140d5a2476f4
@@ -16320,6 +16505,7 @@
 ./packages/api-utils/tests/modules/castor.js 1.9b2 481ddc79abc43c7683449e153d1c12495d2c514aaf2d09a84dcced746d171cf7
 ./packages/api-utils/tests/modules/castor.js 1.9b3 481ddc79abc43c7683449e153d1c12495d2c514aaf2d09a84dcced746d171cf7
 ./packages/api-utils/tests/modules/castor.js 1.9-dev 481ddc79abc43c7683449e153d1c12495d2c514aaf2d09a84dcced746d171cf7
+./packages/api-utils/tests/modules/castor.js 1.9rc1 481ddc79abc43c7683449e153d1c12495d2c514aaf2d09a84dcced746d171cf7
 ./packages/api-utils/tests/modules/cheetah.js 1.0 0da998be114089d6546b7c67f428b8319909ab51d368d9d88946b2c18f75b598
 ./packages/api-utils/tests/modules/cheetah.js 1.0b2 0da998be114089d6546b7c67f428b8319909ab51d368d9d88946b2c18f75b598
 ./packages/api-utils/tests/modules/cheetah.js 1.0b2rc1 0da998be114089d6546b7c67f428b8319909ab51d368d9d88946b2c18f75b598
@@ -16406,6 +16592,7 @@
 ./packages/api-utils/tests/modules/cheetah.js 1.9b2 399616b6528808d7035984785f08edc6d27df50bc65bf4889b74071ad9b6276a
 ./packages/api-utils/tests/modules/cheetah.js 1.9b3 399616b6528808d7035984785f08edc6d27df50bc65bf4889b74071ad9b6276a
 ./packages/api-utils/tests/modules/cheetah.js 1.9-dev 399616b6528808d7035984785f08edc6d27df50bc65bf4889b74071ad9b6276a
+./packages/api-utils/tests/modules/cheetah.js 1.9rc1 399616b6528808d7035984785f08edc6d27df50bc65bf4889b74071ad9b6276a
 ./packages/api-utils/tests/modules/color.js 1.0b2 e759722894b8d8a0398a1a8be7696102e153f30304f5e6dc0c799b9687dc16a0
 ./packages/api-utils/tests/modules/color.js 1.0b2rc1 e759722894b8d8a0398a1a8be7696102e153f30304f5e6dc0c799b9687dc16a0
 ./packages/api-utils/tests/modules/color.js 1.0b3 e759722894b8d8a0398a1a8be7696102e153f30304f5e6dc0c799b9687dc16a0
@@ -16492,6 +16679,7 @@
 ./packages/api-utils/tests/modules/color.js 1.9b2 ffe7e79e2d77562eadfa2e91296af47c06086b00e44800d984da704ae22e1cf1
 ./packages/api-utils/tests/modules/color.js 1.9b3 ffe7e79e2d77562eadfa2e91296af47c06086b00e44800d984da704ae22e1cf1
 ./packages/api-utils/tests/modules/color.js 1.9-dev ffe7e79e2d77562eadfa2e91296af47c06086b00e44800d984da704ae22e1cf1
+./packages/api-utils/tests/modules/color.js 1.9rc1 ffe7e79e2d77562eadfa2e91296af47c06086b00e44800d984da704ae22e1cf1
 ./packages/api-utils/tests/modules/dupe.js 1.0 4f26fa056604dbb9c7b9704eb3f313771abc1d1bea6d1a8fef8562eb6c09b5ee
 ./packages/api-utils/tests/modules/dupe.js 1.0b2 4f26fa056604dbb9c7b9704eb3f313771abc1d1bea6d1a8fef8562eb6c09b5ee
 ./packages/api-utils/tests/modules/dupe.js 1.0b2rc1 4f26fa056604dbb9c7b9704eb3f313771abc1d1bea6d1a8fef8562eb6c09b5ee
@@ -16578,6 +16766,7 @@
 ./packages/api-utils/tests/modules/dupe.js 1.9b2 378333f70aa5ce1e3c407b14098043b16a2d3ca8789fe781e46230b4ea5ec6b8
 ./packages/api-utils/tests/modules/dupe.js 1.9b3 378333f70aa5ce1e3c407b14098043b16a2d3ca8789fe781e46230b4ea5ec6b8
 ./packages/api-utils/tests/modules/dupe.js 1.9-dev 378333f70aa5ce1e3c407b14098043b16a2d3ca8789fe781e46230b4ea5ec6b8
+./packages/api-utils/tests/modules/dupe.js 1.9rc1 378333f70aa5ce1e3c407b14098043b16a2d3ca8789fe781e46230b4ea5ec6b8
 ./packages/api-utils/tests/modules/dupeNested.js 1.0 30f7c950866a69fee5c0056458b14eec8b1959d9e1b0c50e1ba2d45f9f535973
 ./packages/api-utils/tests/modules/dupeNested.js 1.0b2 30f7c950866a69fee5c0056458b14eec8b1959d9e1b0c50e1ba2d45f9f535973
 ./packages/api-utils/tests/modules/dupeNested.js 1.0b2rc1 30f7c950866a69fee5c0056458b14eec8b1959d9e1b0c50e1ba2d45f9f535973
@@ -16664,6 +16853,7 @@
 ./packages/api-utils/tests/modules/dupeNested.js 1.9b2 64e7ab33202d16c97a2fd909132a4d7ffb02a8ccf0a1967d029e41ecb7c6a900
 ./packages/api-utils/tests/modules/dupeNested.js 1.9b3 64e7ab33202d16c97a2fd909132a4d7ffb02a8ccf0a1967d029e41ecb7c6a900
 ./packages/api-utils/tests/modules/dupeNested.js 1.9-dev 64e7ab33202d16c97a2fd909132a4d7ffb02a8ccf0a1967d029e41ecb7c6a900
+./packages/api-utils/tests/modules/dupeNested.js 1.9rc1 64e7ab33202d16c97a2fd909132a4d7ffb02a8ccf0a1967d029e41ecb7c6a900
 ./packages/api-utils/tests/modules/dupeSetExports.js 1.0 16daf5a4e3dc4cd9b75a8f34dad78a81ffececef15f61d64ac62722c9a2abd69
 ./packages/api-utils/tests/modules/dupeSetExports.js 1.0b2 16daf5a4e3dc4cd9b75a8f34dad78a81ffececef15f61d64ac62722c9a2abd69
 ./packages/api-utils/tests/modules/dupeSetExports.js 1.0b2rc1 16daf5a4e3dc4cd9b75a8f34dad78a81ffececef15f61d64ac62722c9a2abd69
@@ -16750,6 +16940,7 @@
 ./packages/api-utils/tests/modules/dupeSetExports.js 1.9b2 28859ca53d10b4b691e3a9977058416c6aa67f113bab5fca6187195c1f9a7435
 ./packages/api-utils/tests/modules/dupeSetExports.js 1.9b3 28859ca53d10b4b691e3a9977058416c6aa67f113bab5fca6187195c1f9a7435
 ./packages/api-utils/tests/modules/dupeSetExports.js 1.9-dev 28859ca53d10b4b691e3a9977058416c6aa67f113bab5fca6187195c1f9a7435
+./packages/api-utils/tests/modules/dupeSetExports.js 1.9rc1 28859ca53d10b4b691e3a9977058416c6aa67f113bab5fca6187195c1f9a7435
 ./packages/api-utils/tests/modules/exportsEquals.js 1.0b2 d74e3b88b75663a07cfa31b1c1a7cef8c6b37b5f289ca5d84037c89e664f363b
 ./packages/api-utils/tests/modules/exportsEquals.js 1.0b2rc1 d74e3b88b75663a07cfa31b1c1a7cef8c6b37b5f289ca5d84037c89e664f363b
 ./packages/api-utils/tests/modules/exportsEquals.js 1.0b3 d74e3b88b75663a07cfa31b1c1a7cef8c6b37b5f289ca5d84037c89e664f363b
@@ -16836,6 +17027,7 @@
 ./packages/api-utils/tests/modules/exportsEquals.js 1.9b2 a026bdd15215e0b4428c2bf6b65940625b7f468f335725a6edab26d99d025cfa
 ./packages/api-utils/tests/modules/exportsEquals.js 1.9b3 a026bdd15215e0b4428c2bf6b65940625b7f468f335725a6edab26d99d025cfa
 ./packages/api-utils/tests/modules/exportsEquals.js 1.9-dev a026bdd15215e0b4428c2bf6b65940625b7f468f335725a6edab26d99d025cfa
+./packages/api-utils/tests/modules/exportsEquals.js 1.9rc1 a026bdd15215e0b4428c2bf6b65940625b7f468f335725a6edab26d99d025cfa
 ./packages/api-utils/tests/modules/green.js 1.0 3f3eac8e8891a92fa7f510d4390e3129b1d4f993f7d7a9ca4a71f5ae2d8547e7
 ./packages/api-utils/tests/modules/green.js 1.0b2 3f3eac8e8891a92fa7f510d4390e3129b1d4f993f7d7a9ca4a71f5ae2d8547e7
 ./packages/api-utils/tests/modules/green.js 1.0b2rc1 3f3eac8e8891a92fa7f510d4390e3129b1d4f993f7d7a9ca4a71f5ae2d8547e7
@@ -16922,6 +17114,7 @@
 ./packages/api-utils/tests/modules/green.js 1.9b2 0d826b04d2ac4473aef9dd1fdfd9f91bf4017df740ebe25581240e783a5c2157
 ./packages/api-utils/tests/modules/green.js 1.9b3 0d826b04d2ac4473aef9dd1fdfd9f91bf4017df740ebe25581240e783a5c2157
 ./packages/api-utils/tests/modules/green.js 1.9-dev 0d826b04d2ac4473aef9dd1fdfd9f91bf4017df740ebe25581240e783a5c2157
+./packages/api-utils/tests/modules/green.js 1.9rc1 0d826b04d2ac4473aef9dd1fdfd9f91bf4017df740ebe25581240e783a5c2157
 ./packages/api-utils/tests/modules/lion.js 1.0b2 f6105c2970d800defc90f9922e7c17e210a3ceeefbe378bc6917a9b6d0527b56
 ./packages/api-utils/tests/modules/lion.js 1.0b2rc1 f6105c2970d800defc90f9922e7c17e210a3ceeefbe378bc6917a9b6d0527b56
 ./packages/api-utils/tests/modules/lion.js 1.0b3 f6105c2970d800defc90f9922e7c17e210a3ceeefbe378bc6917a9b6d0527b56
@@ -17008,6 +17201,7 @@
 ./packages/api-utils/tests/modules/lion.js 1.9b2 3ee59c88de39c197a5d38a582ae00a4fffb721c69cc1f426de6c5c2695f194f1
 ./packages/api-utils/tests/modules/lion.js 1.9b3 3ee59c88de39c197a5d38a582ae00a4fffb721c69cc1f426de6c5c2695f194f1
 ./packages/api-utils/tests/modules/lion.js 1.9-dev 3ee59c88de39c197a5d38a582ae00a4fffb721c69cc1f426de6c5c2695f194f1
+./packages/api-utils/tests/modules/lion.js 1.9rc1 3ee59c88de39c197a5d38a582ae00a4fffb721c69cc1f426de6c5c2695f194f1
 ./packages/api-utils/tests/modules/orange.js 1.0 76b90699eb0031d7cd521f10158648ad5413971fa73e92759d990e40d7743432
 ./packages/api-utils/tests/modules/orange.js 1.0b2 76b90699eb0031d7cd521f10158648ad5413971fa73e92759d990e40d7743432
 ./packages/api-utils/tests/modules/orange.js 1.0b2rc1 76b90699eb0031d7cd521f10158648ad5413971fa73e92759d990e40d7743432
@@ -17094,6 +17288,7 @@
 ./packages/api-utils/tests/modules/orange.js 1.9b2 84d798d3a41ae684657ef7184958b4ecfa8366b4b5981643adac1455dd572884
 ./packages/api-utils/tests/modules/orange.js 1.9b3 84d798d3a41ae684657ef7184958b4ecfa8366b4b5981643adac1455dd572884
 ./packages/api-utils/tests/modules/orange.js 1.9-dev 84d798d3a41ae684657ef7184958b4ecfa8366b4b5981643adac1455dd572884
+./packages/api-utils/tests/modules/orange.js 1.9rc1 84d798d3a41ae684657ef7184958b4ecfa8366b4b5981643adac1455dd572884
 ./packages/api-utils/tests/modules/pollux.js 1.0 6ccf1a2470965f102b7c83887d6e458c8f5b72a7dd31a691a065dc37459e1c26
 ./packages/api-utils/tests/modules/pollux.js 1.0b2 6ccf1a2470965f102b7c83887d6e458c8f5b72a7dd31a691a065dc37459e1c26
 ./packages/api-utils/tests/modules/pollux.js 1.0b2rc1 6ccf1a2470965f102b7c83887d6e458c8f5b72a7dd31a691a065dc37459e1c26
@@ -17180,6 +17375,7 @@
 ./packages/api-utils/tests/modules/pollux.js 1.9b2 0ad331ddee2fa8917d55486e547cb9e6106e7566d48f65df0a78b27904983376
 ./packages/api-utils/tests/modules/pollux.js 1.9b3 0ad331ddee2fa8917d55486e547cb9e6106e7566d48f65df0a78b27904983376
 ./packages/api-utils/tests/modules/pollux.js 1.9-dev 0ad331ddee2fa8917d55486e547cb9e6106e7566d48f65df0a78b27904983376
+./packages/api-utils/tests/modules/pollux.js 1.9rc1 0ad331ddee2fa8917d55486e547cb9e6106e7566d48f65df0a78b27904983376
 ./packages/api-utils/tests/modules/red.js 1.0 4b8c71077b636087b5a14b2a413e40d53b2eca346a559c3ab6b2727660d8a140
 ./packages/api-utils/tests/modules/red.js 1.0b2 4b8c71077b636087b5a14b2a413e40d53b2eca346a559c3ab6b2727660d8a140
 ./packages/api-utils/tests/modules/red.js 1.0b2rc1 4b8c71077b636087b5a14b2a413e40d53b2eca346a559c3ab6b2727660d8a140
@@ -17266,6 +17462,7 @@
 ./packages/api-utils/tests/modules/red.js 1.9b2 2b413bdfcee0a4173581431e8683c00130f492d86f164fb02436da39482623cd
 ./packages/api-utils/tests/modules/red.js 1.9b3 2b413bdfcee0a4173581431e8683c00130f492d86f164fb02436da39482623cd
 ./packages/api-utils/tests/modules/red.js 1.9-dev 2b413bdfcee0a4173581431e8683c00130f492d86f164fb02436da39482623cd
+./packages/api-utils/tests/modules/red.js 1.9rc1 2b413bdfcee0a4173581431e8683c00130f492d86f164fb02436da39482623cd
 ./packages/api-utils/tests/modules/setExports.js 1.0 82a2e37f195b4ff8af571dc4e4aedaeafe1df100603de3bf6be82cd2bc2661a0
 ./packages/api-utils/tests/modules/setExports.js 1.0b2 82a2e37f195b4ff8af571dc4e4aedaeafe1df100603de3bf6be82cd2bc2661a0
 ./packages/api-utils/tests/modules/setExports.js 1.0b2rc1 82a2e37f195b4ff8af571dc4e4aedaeafe1df100603de3bf6be82cd2bc2661a0
@@ -17352,6 +17549,7 @@
 ./packages/api-utils/tests/modules/setExports.js 1.9b2 6fa9aab5518494b408facfb71de37e94e0060a836c4b0ceab21934df1a137329
 ./packages/api-utils/tests/modules/setExports.js 1.9b3 6fa9aab5518494b408facfb71de37e94e0060a836c4b0ceab21934df1a137329
 ./packages/api-utils/tests/modules/setExports.js 1.9-dev 6fa9aab5518494b408facfb71de37e94e0060a836c4b0ceab21934df1a137329
+./packages/api-utils/tests/modules/setExports.js 1.9rc1 6fa9aab5518494b408facfb71de37e94e0060a836c4b0ceab21934df1a137329
 ./packages/api-utils/tests/modules/sheep.js 1.0b2 248aad52321ec8b37bac6d1128f4f2dd6829355b05cf3ff6f895a560d515aa51
 ./packages/api-utils/tests/modules/sheep.js 1.0b2rc1 248aad52321ec8b37bac6d1128f4f2dd6829355b05cf3ff6f895a560d515aa51
 ./packages/api-utils/tests/modules/sheep.js 1.0b3 248aad52321ec8b37bac6d1128f4f2dd6829355b05cf3ff6f895a560d515aa51
@@ -17449,6 +17647,7 @@
 ./packages/api-utils/tests/modules/subtract.js 1.9b2 ff91ad40ce423f3feaae34a51aa7b40412d3aba4337911fb16e2563dc310246f
 ./packages/api-utils/tests/modules/subtract.js 1.9b3 ff91ad40ce423f3feaae34a51aa7b40412d3aba4337911fb16e2563dc310246f
 ./packages/api-utils/tests/modules/subtract.js 1.9-dev ff91ad40ce423f3feaae34a51aa7b40412d3aba4337911fb16e2563dc310246f
+./packages/api-utils/tests/modules/subtract.js 1.9rc1 ff91ad40ce423f3feaae34a51aa7b40412d3aba4337911fb16e2563dc310246f
 ./packages/api-utils/tests/modules/tiger.js 1.0b2 df8566f1d59fbe39f5da1a40b1118242cf8ed6ed02695580138655dfc4d1d02d
 ./packages/api-utils/tests/modules/tiger.js 1.0b2rc1 df8566f1d59fbe39f5da1a40b1118242cf8ed6ed02695580138655dfc4d1d02d
 ./packages/api-utils/tests/modules/tiger.js 1.0b3 df8566f1d59fbe39f5da1a40b1118242cf8ed6ed02695580138655dfc4d1d02d
@@ -17535,6 +17734,7 @@
 ./packages/api-utils/tests/modules/tiger.js 1.9b2 525ce8db6cc0b032433cb9325b52468878a7b6ba337d3e4884d1833b5fb9c501
 ./packages/api-utils/tests/modules/tiger.js 1.9b3 525ce8db6cc0b032433cb9325b52468878a7b6ba337d3e4884d1833b5fb9c501
 ./packages/api-utils/tests/modules/tiger.js 1.9-dev 525ce8db6cc0b032433cb9325b52468878a7b6ba337d3e4884d1833b5fb9c501
+./packages/api-utils/tests/modules/tiger.js 1.9rc1 525ce8db6cc0b032433cb9325b52468878a7b6ba337d3e4884d1833b5fb9c501
 ./packages/api-utils/tests/modules/traditional1.js 1.0b2 ccfb8c703d6203da48ea486f8d6fd2c017999568019dc25663f6e9eeb62ed0c9
 ./packages/api-utils/tests/modules/traditional1.js 1.0b2rc1 ccfb8c703d6203da48ea486f8d6fd2c017999568019dc25663f6e9eeb62ed0c9
 ./packages/api-utils/tests/modules/traditional1.js 1.0b3 ccfb8c703d6203da48ea486f8d6fd2c017999568019dc25663f6e9eeb62ed0c9
@@ -17621,6 +17821,7 @@
 ./packages/api-utils/tests/modules/traditional1.js 1.9b2 62e3c510d3f69ae14fe17092b9ab9f0af8f5af463a97d20c777418a5b0e8e1f6
 ./packages/api-utils/tests/modules/traditional1.js 1.9b3 62e3c510d3f69ae14fe17092b9ab9f0af8f5af463a97d20c777418a5b0e8e1f6
 ./packages/api-utils/tests/modules/traditional1.js 1.9-dev 62e3c510d3f69ae14fe17092b9ab9f0af8f5af463a97d20c777418a5b0e8e1f6
+./packages/api-utils/tests/modules/traditional1.js 1.9rc1 62e3c510d3f69ae14fe17092b9ab9f0af8f5af463a97d20c777418a5b0e8e1f6
 ./packages/api-utils/tests/modules/traditional2.js 1.0 6dd9c955f0719c100f216006ce22100e5794af005997ea669d5e1b0139689d3d
 ./packages/api-utils/tests/modules/traditional2.js 1.0b2 6dd9c955f0719c100f216006ce22100e5794af005997ea669d5e1b0139689d3d
 ./packages/api-utils/tests/modules/traditional2.js 1.0b2rc1 6dd9c955f0719c100f216006ce22100e5794af005997ea669d5e1b0139689d3d
@@ -17707,6 +17908,7 @@
 ./packages/api-utils/tests/modules/traditional2.js 1.9b2 90cb29c1122b3a27d95bd734f9e49db705da931cd58c1a319ffeca74a3983319
 ./packages/api-utils/tests/modules/traditional2.js 1.9b3 90cb29c1122b3a27d95bd734f9e49db705da931cd58c1a319ffeca74a3983319
 ./packages/api-utils/tests/modules/traditional2.js 1.9-dev 90cb29c1122b3a27d95bd734f9e49db705da931cd58c1a319ffeca74a3983319
+./packages/api-utils/tests/modules/traditional2.js 1.9rc1 90cb29c1122b3a27d95bd734f9e49db705da931cd58c1a319ffeca74a3983319
 ./packages/api-utils/tests/modules/types/cat.js 1.0b2 fc316e4f7e57c4df5614c85cffb178ec38b61277acb8edb774d06ee098789b3c
 ./packages/api-utils/tests/modules/types/cat.js 1.0b2rc1 fc316e4f7e57c4df5614c85cffb178ec38b61277acb8edb774d06ee098789b3c
 ./packages/api-utils/tests/modules/types/cat.js 1.0b3 fc316e4f7e57c4df5614c85cffb178ec38b61277acb8edb774d06ee098789b3c
@@ -17793,6 +17995,7 @@
 ./packages/api-utils/tests/modules/types/cat.js 1.9b2 67cef55e2e66bf2ffbb8420b8e3b58e6f3174fc0cfc4d0cfa28cd31455f2a7f3
 ./packages/api-utils/tests/modules/types/cat.js 1.9b3 67cef55e2e66bf2ffbb8420b8e3b58e6f3174fc0cfc4d0cfa28cd31455f2a7f3
 ./packages/api-utils/tests/modules/types/cat.js 1.9-dev 67cef55e2e66bf2ffbb8420b8e3b58e6f3174fc0cfc4d0cfa28cd31455f2a7f3
+./packages/api-utils/tests/modules/types/cat.js 1.9rc1 67cef55e2e66bf2ffbb8420b8e3b58e6f3174fc0cfc4d0cfa28cd31455f2a7f3
 ./packages/api-utils/tests/test-addon-installer.js 1.10-dev 920345eb7c0eb90cbc6846fa56167aca03916f44069bb140f7237a04b34c244f
 ./packages/api-utils/tests/test-addon-installer.js 1.8.1 920345eb7c0eb90cbc6846fa56167aca03916f44069bb140f7237a04b34c244f
 ./packages/api-utils/tests/test-addon-installer.js 1.8.2 920345eb7c0eb90cbc6846fa56167aca03916f44069bb140f7237a04b34c244f
@@ -17807,6 +18010,7 @@
 ./packages/api-utils/tests/test-addon-installer.js 1.9b2 920345eb7c0eb90cbc6846fa56167aca03916f44069bb140f7237a04b34c244f
 ./packages/api-utils/tests/test-addon-installer.js 1.9b3 920345eb7c0eb90cbc6846fa56167aca03916f44069bb140f7237a04b34c244f
 ./packages/api-utils/tests/test-addon-installer.js 1.9-dev 920345eb7c0eb90cbc6846fa56167aca03916f44069bb140f7237a04b34c244f
+./packages/api-utils/tests/test-addon-installer.js 1.9rc1 920345eb7c0eb90cbc6846fa56167aca03916f44069bb140f7237a04b34c244f
 ./packages/api-utils/tests/test-api-utils.js 1.0 19a163af16fc68f2ffda2dd27d792723a6c3ef2a3bd3fce54e8e204feb72be91
 ./packages/api-utils/tests/test-api-utils.js 1.0b1 19a163af16fc68f2ffda2dd27d792723a6c3ef2a3bd3fce54e8e204feb72be91
 ./packages/api-utils/tests/test-api-utils.js 1.0b1rc1 19a163af16fc68f2ffda2dd27d792723a6c3ef2a3bd3fce54e8e204feb72be91
@@ -17898,6 +18102,7 @@
 ./packages/api-utils/tests/test-api-utils.js 1.9b2 2c44eaf596edc5e3d9561e723a762d5c095b29fd749a420815dbfe4fe81ba814
 ./packages/api-utils/tests/test-api-utils.js 1.9b3 2c44eaf596edc5e3d9561e723a762d5c095b29fd749a420815dbfe4fe81ba814
 ./packages/api-utils/tests/test-api-utils.js 1.9-dev 2c44eaf596edc5e3d9561e723a762d5c095b29fd749a420815dbfe4fe81ba814
+./packages/api-utils/tests/test-api-utils.js 1.9rc1 2c44eaf596edc5e3d9561e723a762d5c095b29fd749a420815dbfe4fe81ba814
 ./packages/api-utils/tests/test-app-strings.js 1.0 248c515ff1f47969c0b608dfab79ca4f94d4eb11fa8f694896a48c4cf1637f6c
 ./packages/api-utils/tests/test-app-strings.js 1.0b1 248c515ff1f47969c0b608dfab79ca4f94d4eb11fa8f694896a48c4cf1637f6c
 ./packages/api-utils/tests/test-app-strings.js 1.0b1rc1 248c515ff1f47969c0b608dfab79ca4f94d4eb11fa8f694896a48c4cf1637f6c
@@ -17989,6 +18194,7 @@
 ./packages/api-utils/tests/test-app-strings.js 1.9b2 f8af9f66a33e94b4b680193a18887b5695b715da24af77069508ff62c1179039
 ./packages/api-utils/tests/test-app-strings.js 1.9b3 f8af9f66a33e94b4b680193a18887b5695b715da24af77069508ff62c1179039
 ./packages/api-utils/tests/test-app-strings.js 1.9-dev f8af9f66a33e94b4b680193a18887b5695b715da24af77069508ff62c1179039
+./packages/api-utils/tests/test-app-strings.js 1.9rc1 f8af9f66a33e94b4b680193a18887b5695b715da24af77069508ff62c1179039
 ./packages/api-utils/tests/test-array.js 1.10-dev 9601d4f4dc584d97a3dbc2ab5768ffda66c7c0d8cbb87d9dce6415030ef430dd
 ./packages/api-utils/tests/test-array.js 1.1 57a588d5143e096f481d3bb484f1aabd5886eebfd1fcb5fbfbb88ac4c9b39ecd
 ./packages/api-utils/tests/test-array.js 1.1a1 57a588d5143e096f481d3bb484f1aabd5886eebfd1fcb5fbfbb88ac4c9b39ecd
@@ -18056,10 +18262,12 @@
 ./packages/api-utils/tests/test-array.js 1.9b2 9601d4f4dc584d97a3dbc2ab5768ffda66c7c0d8cbb87d9dce6415030ef430dd
 ./packages/api-utils/tests/test-array.js 1.9b3 9601d4f4dc584d97a3dbc2ab5768ffda66c7c0d8cbb87d9dce6415030ef430dd
 ./packages/api-utils/tests/test-array.js 1.9-dev 9601d4f4dc584d97a3dbc2ab5768ffda66c7c0d8cbb87d9dce6415030ef430dd
+./packages/api-utils/tests/test-array.js 1.9rc1 9601d4f4dc584d97a3dbc2ab5768ffda66c7c0d8cbb87d9dce6415030ef430dd
 ./packages/api-utils/tests/test-base64.js 1.10-dev f8d974fb580d4f35096864669664e15ffbd73915a6cded723603f1f29929dcfe
 ./packages/api-utils/tests/test-base64.js 1.9b1 f8d974fb580d4f35096864669664e15ffbd73915a6cded723603f1f29929dcfe
 ./packages/api-utils/tests/test-base64.js 1.9b2 f8d974fb580d4f35096864669664e15ffbd73915a6cded723603f1f29929dcfe
 ./packages/api-utils/tests/test-base64.js 1.9b3 f8d974fb580d4f35096864669664e15ffbd73915a6cded723603f1f29929dcfe
+./packages/api-utils/tests/test-base64.js 1.9rc1 f8d974fb580d4f35096864669664e15ffbd73915a6cded723603f1f29929dcfe
 ./packages/api-utils/tests/test-base.js 1.5b1 bbf92cd83126144cb2fa113e88b437a592e4e2f8f487afb159233c25f01f909a
 ./packages/api-utils/tests/test-base.js 1.5b2 bbf92cd83126144cb2fa113e88b437a592e4e2f8f487afb159233c25f01f909a
 ./packages/api-utils/tests/test-base.js 1.5b3 bbf92cd83126144cb2fa113e88b437a592e4e2f8f487afb159233c25f01f909a
@@ -18172,6 +18380,7 @@
 ./packages/api-utils/tests/test-byte-streams.js 1.9b2 d5da7c4903257918d5fc7b8b5d3a1da68f12c6644aac0ccd28bff1771662510e
 ./packages/api-utils/tests/test-byte-streams.js 1.9b3 d5da7c4903257918d5fc7b8b5d3a1da68f12c6644aac0ccd28bff1771662510e
 ./packages/api-utils/tests/test-byte-streams.js 1.9-dev d5da7c4903257918d5fc7b8b5d3a1da68f12c6644aac0ccd28bff1771662510e
+./packages/api-utils/tests/test-byte-streams.js 1.9rc1 d5da7c4903257918d5fc7b8b5d3a1da68f12c6644aac0ccd28bff1771662510e
 ./packages/api-utils/tests/test-collection.js 1.0 67b5bae3aa94c9a1949a15d0715b242c9ead508d0344c33e52093541b2e8a0cf
 ./packages/api-utils/tests/test-collection.js 1.0b1 67b5bae3aa94c9a1949a15d0715b242c9ead508d0344c33e52093541b2e8a0cf
 ./packages/api-utils/tests/test-collection.js 1.0b1rc1 67b5bae3aa94c9a1949a15d0715b242c9ead508d0344c33e52093541b2e8a0cf
@@ -18263,6 +18472,7 @@
 ./packages/api-utils/tests/test-collection.js 1.9b2 11c79139d83022b42835ca4e2a980015944192173b998caca831808a83b6aaad
 ./packages/api-utils/tests/test-collection.js 1.9b3 11c79139d83022b42835ca4e2a980015944192173b998caca831808a83b6aaad
 ./packages/api-utils/tests/test-collection.js 1.9-dev 11c79139d83022b42835ca4e2a980015944192173b998caca831808a83b6aaad
+./packages/api-utils/tests/test-collection.js 1.9rc1 11c79139d83022b42835ca4e2a980015944192173b998caca831808a83b6aaad
 ./packages/api-utils/tests/test-commonjs-test-adapter.js 1.0 68ac5a50cd1535c94944507cd937e67b91da58c8793acf92110db70e6cdad14d
 ./packages/api-utils/tests/test-commonjs-test-adapter.js 1.0b3 68ac5a50cd1535c94944507cd937e67b91da58c8793acf92110db70e6cdad14d
 ./packages/api-utils/tests/test-commonjs-test-adapter.js 1.0b3rc1 68ac5a50cd1535c94944507cd937e67b91da58c8793acf92110db70e6cdad14d
@@ -18347,6 +18557,7 @@
 ./packages/api-utils/tests/test-commonjs-test-adapter.js 1.9b2 19b532b63d0c8fc9697a461371d5ede433c2d4f6cf0f038df48c841fb1e1a715
 ./packages/api-utils/tests/test-commonjs-test-adapter.js 1.9b3 19b532b63d0c8fc9697a461371d5ede433c2d4f6cf0f038df48c841fb1e1a715
 ./packages/api-utils/tests/test-commonjs-test-adapter.js 1.9-dev 19b532b63d0c8fc9697a461371d5ede433c2d4f6cf0f038df48c841fb1e1a715
+./packages/api-utils/tests/test-commonjs-test-adapter.js 1.9rc1 19b532b63d0c8fc9697a461371d5ede433c2d4f6cf0f038df48c841fb1e1a715
 ./packages/api-utils/tests/test-content-loader.js 1.0 0950385a994560b2c907041e7f9c97854920c2066e1b2df809ff4abffc6cf6fc
 ./packages/api-utils/tests/test-content-loader.js 1.0b1 21acf57b0cb9b4452f01e3b70851086212cdd286cc5dd58daf489e205e42e061
 ./packages/api-utils/tests/test-content-loader.js 1.0b1rc1 dfb7f94d951defd2d0a29f3bb38c36063bca0620103e818ab130d26f37437b67
@@ -18438,6 +18649,7 @@
 ./packages/api-utils/tests/test-content-loader.js 1.9b2 033377a0ac4a9e2af0fbc160573a5271ffed14734eecbb7cbf8fc99ac3457773
 ./packages/api-utils/tests/test-content-loader.js 1.9b3 033377a0ac4a9e2af0fbc160573a5271ffed14734eecbb7cbf8fc99ac3457773
 ./packages/api-utils/tests/test-content-loader.js 1.9-dev 033377a0ac4a9e2af0fbc160573a5271ffed14734eecbb7cbf8fc99ac3457773
+./packages/api-utils/tests/test-content-loader.js 1.9rc1 033377a0ac4a9e2af0fbc160573a5271ffed14734eecbb7cbf8fc99ac3457773
 ./packages/api-utils/tests/test-content-proxy.js 1.0 ad24191da2ca1d78cbea93e7dc4bfd5391f7ebc453a84e258be5d6b29b2b8261
 ./packages/api-utils/tests/test-content-proxy.js 1.0rc1 f801725e3a09529b567751935660d2899c22a41343690be84e6d9ae3e10a2c25
 ./packages/api-utils/tests/test-content-proxy.js 1.0rc2 ad24191da2ca1d78cbea93e7dc4bfd5391f7ebc453a84e258be5d6b29b2b8261
@@ -18510,6 +18722,7 @@
 ./packages/api-utils/tests/test-content-proxy.js 1.9b2 683df7c6c268b293cd4aa3db6a3f05cf279ba256088c8c9a5376ba891427bdc4
 ./packages/api-utils/tests/test-content-proxy.js 1.9b3 683df7c6c268b293cd4aa3db6a3f05cf279ba256088c8c9a5376ba891427bdc4
 ./packages/api-utils/tests/test-content-proxy.js 1.9-dev 3888f1b910c1747c59b183b38e931ab2b33f84758ffd1f35eed257cd3308782e
+./packages/api-utils/tests/test-content-proxy.js 1.9rc1 683df7c6c268b293cd4aa3db6a3f05cf279ba256088c8c9a5376ba891427bdc4
 ./packages/api-utils/tests/test-content-symbiont.js 1.0 a1b274f5f0515c875a1a38dba81e6d6591ae1fc16b0937fc62a8c0da425eccd8
 ./packages/api-utils/tests/test-content-symbiont.js 1.0b1 23ec2993b059f548f708e5f4b2d474edc68ecdb373694b6d1c6ec9c5d3b0212f
 ./packages/api-utils/tests/test-content-symbiont.js 1.0b1rc1 23ec2993b059f548f708e5f4b2d474edc68ecdb373694b6d1c6ec9c5d3b0212f
@@ -18601,6 +18814,7 @@
 ./packages/api-utils/tests/test-content-symbiont.js 1.9b2 f1ebdb70a11316a26fbf32d7ab69e9a5c03496ffc1b3601486366f2fa5b40b6a
 ./packages/api-utils/tests/test-content-symbiont.js 1.9b3 f1ebdb70a11316a26fbf32d7ab69e9a5c03496ffc1b3601486366f2fa5b40b6a
 ./packages/api-utils/tests/test-content-symbiont.js 1.9-dev 132ad8b9a41ba266998dfa2c83559c43d7e0e148fb03ac67475c72c7d6bb13d8
+./packages/api-utils/tests/test-content-symbiont.js 1.9rc1 f1ebdb70a11316a26fbf32d7ab69e9a5c03496ffc1b3601486366f2fa5b40b6a
 ./packages/api-utils/tests/test-content-worker.js 1.0b1 229977cf0bdbeb4699ab39af8dfb8b33d51a482bb87f6f0cede013ebbb7c3394
 ./packages/api-utils/tests/test-content-worker.js 1.0b1rc1 229977cf0bdbeb4699ab39af8dfb8b33d51a482bb87f6f0cede013ebbb7c3394
 ./packages/api-utils/tests/test-content-worker.js 1.0b1rc2 229977cf0bdbeb4699ab39af8dfb8b33d51a482bb87f6f0cede013ebbb7c3394
@@ -18692,6 +18906,7 @@
 ./packages/api-utils/tests/test-content-worker.js 1.9b2 4638f0bf24cf8935d4de05ffccb3b505d0d7e69d6288d19204575b0f52c47c15
 ./packages/api-utils/tests/test-content-worker.js 1.9b3 4638f0bf24cf8935d4de05ffccb3b505d0d7e69d6288d19204575b0f52c47c15
 ./packages/api-utils/tests/test-content-worker.js 1.9-dev e272c7cb6fbdc304a64bcc7a5a4e7f89a945d19603fbea40243f6232bf0d8aa6
+./packages/api-utils/tests/test-content-worker.js 1.9rc1 4638f0bf24cf8935d4de05ffccb3b505d0d7e69d6288d19204575b0f52c47c15
 ./packages/api-utils/tests/test-cortex.js 1.0b3 cc26f7afe736089f8450ac2fc3f59176776b06ae8c25ada3b328821be388cece
 ./packages/api-utils/tests/test-cortex.js 1.0b3rc1 cc26f7afe736089f8450ac2fc3f59176776b06ae8c25ada3b328821be388cece
 ./packages/api-utils/tests/test-cortex.js 1.0b3rc2 cc26f7afe736089f8450ac2fc3f59176776b06ae8c25ada3b328821be388cece
@@ -18776,6 +18991,7 @@
 ./packages/api-utils/tests/test-cortex.js 1.9b2 43b5ac3b09155131532060c9d47b1c7b7b1e7cd8a890b776721d5200f7d48584
 ./packages/api-utils/tests/test-cortex.js 1.9b3 43b5ac3b09155131532060c9d47b1c7b7b1e7cd8a890b776721d5200f7d48584
 ./packages/api-utils/tests/test-cortex.js 1.9-dev 43b5ac3b09155131532060c9d47b1c7b7b1e7cd8a890b776721d5200f7d48584
+./packages/api-utils/tests/test-cortex.js 1.9rc1 43b5ac3b09155131532060c9d47b1c7b7b1e7cd8a890b776721d5200f7d48584
 ./packages/api-utils/tests/test-cuddlefish.js 1.0 06fa95ff1c8790f6a4e8ab6c0690b81fad25c47fabd1268e0d61172952585702
 ./packages/api-utils/tests/test-cuddlefish.js 1.0b1 06fa95ff1c8790f6a4e8ab6c0690b81fad25c47fabd1268e0d61172952585702
 ./packages/api-utils/tests/test-cuddlefish.js 1.0b1rc1 06fa95ff1c8790f6a4e8ab6c0690b81fad25c47fabd1268e0d61172952585702
@@ -18819,6 +19035,7 @@
 ./packages/api-utils/tests/test-cuddlefish.js 1.3b3 cdc7fab20a2612c72937d437e1d648ebf6d0489be73db9c0bb32fb93d82d7e33
 ./packages/api-utils/tests/test-cuddlefish.js 1.3 cdc7fab20a2612c72937d437e1d648ebf6d0489be73db9c0bb32fb93d82d7e33
 ./packages/api-utils/tests/test-cuddlefish.js 1.3rc1 cdc7fab20a2612c72937d437e1d648ebf6d0489be73db9c0bb32fb93d82d7e33
+./packages/api-utils/tests/test-cuddlefish.js 1.9rc1 d859e909786aa38a5a549a8db17479973fc9b871ca1adca60b9a894bd520c54e
 ./packages/api-utils/tests/test-dom.js 1.0 65397c5effc4e6c55041781936e603a735aff696bd34148a50113bcc2b1ac03f
 ./packages/api-utils/tests/test-dom.js 1.0b5 65397c5effc4e6c55041781936e603a735aff696bd34148a50113bcc2b1ac03f
 ./packages/api-utils/tests/test-dom.js 1.0b5rc1 65397c5effc4e6c55041781936e603a735aff696bd34148a50113bcc2b1ac03f
@@ -18894,6 +19111,7 @@
 ./packages/api-utils/tests/test-dom.js 1.9b2 5361783735daf4cffde861334a887114a691025c37d400cd23b7de64a1b50c88
 ./packages/api-utils/tests/test-dom.js 1.9b3 5361783735daf4cffde861334a887114a691025c37d400cd23b7de64a1b50c88
 ./packages/api-utils/tests/test-dom.js 1.9-dev 5361783735daf4cffde861334a887114a691025c37d400cd23b7de64a1b50c88
+./packages/api-utils/tests/test-dom.js 1.9rc1 5361783735daf4cffde861334a887114a691025c37d400cd23b7de64a1b50c88
 ./packages/api-utils/tests/test-e10s.js 1.0 1cd7b12618e93767253608ae92389644c0a7078fe194734eb1dfa9577e055381
 ./packages/api-utils/tests/test-e10s.js 1.0b1 6654180fa27b8fd7c9e5fad6318a19ff1917ab1ed6ba4f02813a4bac07f95546
 ./packages/api-utils/tests/test-e10s.js 1.0b1rc1 6654180fa27b8fd7c9e5fad6318a19ff1917ab1ed6ba4f02813a4bac07f95546
@@ -19041,6 +19259,7 @@
 ./packages/api-utils/tests/test-environment.js 1.9b2 e9f443fc7cca4de83b70b1b270a221692017a3a0484058c0ea202b096467478b
 ./packages/api-utils/tests/test-environment.js 1.9b3 e9f443fc7cca4de83b70b1b270a221692017a3a0484058c0ea202b096467478b
 ./packages/api-utils/tests/test-environment.js 1.9-dev e9f443fc7cca4de83b70b1b270a221692017a3a0484058c0ea202b096467478b
+./packages/api-utils/tests/test-environment.js 1.9rc1 e9f443fc7cca4de83b70b1b270a221692017a3a0484058c0ea202b096467478b
 ./packages/api-utils/tests/test-errors.js 1.0 8fb363d4bd963cfde7ff0743f48f0f24d762089e002d45da6a2e97876dd9e783
 ./packages/api-utils/tests/test-errors.js 1.0b1 2e35bc5a37a2aed7f9b3f1d28005646b22938b7422aadd7f8980437c1c257522
 ./packages/api-utils/tests/test-errors.js 1.0b1rc1 2e35bc5a37a2aed7f9b3f1d28005646b22938b7422aadd7f8980437c1c257522
@@ -19132,6 +19351,7 @@
 ./packages/api-utils/tests/test-errors.js 1.9b2 96990bcac9b5442d94c285e4d34e8a7895d94641f107d1e8f751f63ef8531f0b
 ./packages/api-utils/tests/test-errors.js 1.9b3 96990bcac9b5442d94c285e4d34e8a7895d94641f107d1e8f751f63ef8531f0b
 ./packages/api-utils/tests/test-errors.js 1.9-dev 96990bcac9b5442d94c285e4d34e8a7895d94641f107d1e8f751f63ef8531f0b
+./packages/api-utils/tests/test-errors.js 1.9rc1 96990bcac9b5442d94c285e4d34e8a7895d94641f107d1e8f751f63ef8531f0b
 ./packages/api-utils/tests/test-es5.js 1.0b1 1c8ff76c5d550435404df04f7677bc128a8905c6fe97ed54e0c2f6935ede0b87
 ./packages/api-utils/tests/test-es5.js 1.0b1rc1 1c8ff76c5d550435404df04f7677bc128a8905c6fe97ed54e0c2f6935ede0b87
 ./packages/api-utils/tests/test-es5.js 1.0b1rc2 1c8ff76c5d550435404df04f7677bc128a8905c6fe97ed54e0c2f6935ede0b87
@@ -19171,6 +19391,7 @@
 ./packages/api-utils/tests/test-event-core.js 1.9b2 33363485d6d090dc365a3b2f27d1c4890636ea447d022f434b48919fd02b7703
 ./packages/api-utils/tests/test-event-core.js 1.9b3 33363485d6d090dc365a3b2f27d1c4890636ea447d022f434b48919fd02b7703
 ./packages/api-utils/tests/test-event-core.js 1.9-dev 33363485d6d090dc365a3b2f27d1c4890636ea447d022f434b48919fd02b7703
+./packages/api-utils/tests/test-event-core.js 1.9rc1 33363485d6d090dc365a3b2f27d1c4890636ea447d022f434b48919fd02b7703
 ./packages/api-utils/tests/test-events.js 1.0 32ef28dce4f837df5700ab71c99f68f4503624866afb7027db52f0a5fbcd30be
 ./packages/api-utils/tests/test-events.js 1.0b1 b2a355705d7a5156563cb95f3f29a8e00866ae29b408b1886ac6d5622d2055b1
 ./packages/api-utils/tests/test-events.js 1.0b1rc1 ef564ebba6180ce1d85b15aa2c9a52f2cd6f233a12332234fa3c97aabbcfb45e
@@ -19262,6 +19483,7 @@
 ./packages/api-utils/tests/test-events.js 1.9b2 794175ddece47781d9182f4309f48a3df0e242ba6a46eff5b4b45e78a2d25d8d
 ./packages/api-utils/tests/test-events.js 1.9b3 794175ddece47781d9182f4309f48a3df0e242ba6a46eff5b4b45e78a2d25d8d
 ./packages/api-utils/tests/test-events.js 1.9-dev 794175ddece47781d9182f4309f48a3df0e242ba6a46eff5b4b45e78a2d25d8d
+./packages/api-utils/tests/test-events.js 1.9rc1 794175ddece47781d9182f4309f48a3df0e242ba6a46eff5b4b45e78a2d25d8d
 ./packages/api-utils/tests/test-event-target.js 1.10-dev be019ad6e244090a3f3b1e8aee4c4311a43df25a64469a24514d4bbfe7ff1653
 ./packages/api-utils/tests/test-event-target.js 1.7 4c8104e3b849ce1ce180a7d334e4f100f2908f37995c5490db8cb1fb7d946fa4
 ./packages/api-utils/tests/test-event-target.js 1.7b1 4c8104e3b849ce1ce180a7d334e4f100f2908f37995c5490db8cb1fb7d946fa4
@@ -19282,6 +19504,7 @@
 ./packages/api-utils/tests/test-event-target.js 1.9b2 be019ad6e244090a3f3b1e8aee4c4311a43df25a64469a24514d4bbfe7ff1653
 ./packages/api-utils/tests/test-event-target.js 1.9b3 be019ad6e244090a3f3b1e8aee4c4311a43df25a64469a24514d4bbfe7ff1653
 ./packages/api-utils/tests/test-event-target.js 1.9-dev be019ad6e244090a3f3b1e8aee4c4311a43df25a64469a24514d4bbfe7ff1653
+./packages/api-utils/tests/test-event-target.js 1.9rc1 be019ad6e244090a3f3b1e8aee4c4311a43df25a64469a24514d4bbfe7ff1653
 ./packages/api-utils/tests/test-file.js 1.0b1 9f0fc81cf3dbe5736dcd3d4c869d215289a4109ad37ca18d0e8934fe5e3bbe5d
 ./packages/api-utils/tests/test-file.js 1.0b1rc1 9f0fc81cf3dbe5736dcd3d4c869d215289a4109ad37ca18d0e8934fe5e3bbe5d
 ./packages/api-utils/tests/test-file.js 1.0b1rc2 9f0fc81cf3dbe5736dcd3d4c869d215289a4109ad37ca18d0e8934fe5e3bbe5d
@@ -19373,6 +19596,7 @@
 ./packages/api-utils/tests/test-file.js 1.9b2 ae5b17178ec86c4cf7e09460d3c489f78af5145260dd4fa13e6073d52389995b
 ./packages/api-utils/tests/test-file.js 1.9b3 ae5b17178ec86c4cf7e09460d3c489f78af5145260dd4fa13e6073d52389995b
 ./packages/api-utils/tests/test-file.js 1.9-dev ae5b17178ec86c4cf7e09460d3c489f78af5145260dd4fa13e6073d52389995b
+./packages/api-utils/tests/test-file.js 1.9rc1 ae5b17178ec86c4cf7e09460d3c489f78af5145260dd4fa13e6073d52389995b
 ./packages/api-utils/tests/test-frame-utils.js 1.10-dev 5902f3155040a8c27ef37fd5b92fb6dda229a0244ff84665a007e63ba825a216
 ./packages/api-utils/tests/test-frame-utils.js 1.7 9a6395dfca079004b83d63061d30d11235364907efafddd3522b0e5016bb77ed
 ./packages/api-utils/tests/test-frame-utils.js 1.7b1 9a6395dfca079004b83d63061d30d11235364907efafddd3522b0e5016bb77ed
@@ -19393,6 +19617,7 @@
 ./packages/api-utils/tests/test-frame-utils.js 1.9b2 5902f3155040a8c27ef37fd5b92fb6dda229a0244ff84665a007e63ba825a216
 ./packages/api-utils/tests/test-frame-utils.js 1.9b3 5902f3155040a8c27ef37fd5b92fb6dda229a0244ff84665a007e63ba825a216
 ./packages/api-utils/tests/test-frame-utils.js 1.9-dev 9a6395dfca079004b83d63061d30d11235364907efafddd3522b0e5016bb77ed
+./packages/api-utils/tests/test-frame-utils.js 1.9rc1 5902f3155040a8c27ef37fd5b92fb6dda229a0244ff84665a007e63ba825a216
 ./packages/api-utils/tests/test-functional.js 1.10-dev 7e628b354758abaaa580acf7a71891a9bddecbc0b80f94821cc5c6050c0b4e35
 ./packages/api-utils/tests/test-functional.js 1.6.1 7e347d14d9e452de18f5bdfa98967848ffd6e388cd07abcdb1fa1e9c4da5c9b3
 ./packages/api-utils/tests/test-functional.js 1.6.1rc1 7e347d14d9e452de18f5bdfa98967848ffd6e388cd07abcdb1fa1e9c4da5c9b3
@@ -19421,6 +19646,7 @@
 ./packages/api-utils/tests/test-functional.js 1.9b2 7e628b354758abaaa580acf7a71891a9bddecbc0b80f94821cc5c6050c0b4e35
 ./packages/api-utils/tests/test-functional.js 1.9b3 7e628b354758abaaa580acf7a71891a9bddecbc0b80f94821cc5c6050c0b4e35
 ./packages/api-utils/tests/test-functional.js 1.9-dev 7e628b354758abaaa580acf7a71891a9bddecbc0b80f94821cc5c6050c0b4e35
+./packages/api-utils/tests/test-functional.js 1.9rc1 7e628b354758abaaa580acf7a71891a9bddecbc0b80f94821cc5c6050c0b4e35
 ./packages/api-utils/tests/test-function-utils.js 1.0b1 b91cf35b626265f54b8609eb34f1ca3efb63a39207ddb25ae9f9f586bba0a294
 ./packages/api-utils/tests/test-function-utils.js 1.0b1rc1 b91cf35b626265f54b8609eb34f1ca3efb63a39207ddb25ae9f9f586bba0a294
 ./packages/api-utils/tests/test-function-utils.js 1.0b1rc2 b91cf35b626265f54b8609eb34f1ca3efb63a39207ddb25ae9f9f586bba0a294
@@ -19575,6 +19801,7 @@
 ./packages/api-utils/tests/test-globals.js 1.9b2 b586d7087aaef6be0b3537d71202166b01f73adf1e898b8bb0aa41de0ece94a3
 ./packages/api-utils/tests/test-globals.js 1.9b3 b586d7087aaef6be0b3537d71202166b01f73adf1e898b8bb0aa41de0ece94a3
 ./packages/api-utils/tests/test-globals.js 1.9-dev b586d7087aaef6be0b3537d71202166b01f73adf1e898b8bb0aa41de0ece94a3
+./packages/api-utils/tests/test-globals.js 1.9rc1 b586d7087aaef6be0b3537d71202166b01f73adf1e898b8bb0aa41de0ece94a3
 ./packages/api-utils/tests/test-heritage.js 1.10-dev ebd68e7df63056ecafe3942e6701bde74090ed229b97370c79cecdedb29e85f9
 ./packages/api-utils/tests/test-heritage.js 1.8.1 ebd68e7df63056ecafe3942e6701bde74090ed229b97370c79cecdedb29e85f9
 ./packages/api-utils/tests/test-heritage.js 1.8.2 ebd68e7df63056ecafe3942e6701bde74090ed229b97370c79cecdedb29e85f9
@@ -19589,6 +19816,7 @@
 ./packages/api-utils/tests/test-heritage.js 1.9b2 ebd68e7df63056ecafe3942e6701bde74090ed229b97370c79cecdedb29e85f9
 ./packages/api-utils/tests/test-heritage.js 1.9b3 ebd68e7df63056ecafe3942e6701bde74090ed229b97370c79cecdedb29e85f9
 ./packages/api-utils/tests/test-heritage.js 1.9-dev ebd68e7df63056ecafe3942e6701bde74090ed229b97370c79cecdedb29e85f9
+./packages/api-utils/tests/test-heritage.js 1.9rc1 ebd68e7df63056ecafe3942e6701bde74090ed229b97370c79cecdedb29e85f9
 ./packages/api-utils/tests/test-hidden-frame.js 1.0 6f3cc28ac6842f7c50637f3a3455fa61ca22656c21c7abade57b3925bb8329f2
 ./packages/api-utils/tests/test-hidden-frame.js 1.0b1 6f3cc28ac6842f7c50637f3a3455fa61ca22656c21c7abade57b3925bb8329f2
 ./packages/api-utils/tests/test-hidden-frame.js 1.0b1rc1 6f3cc28ac6842f7c50637f3a3455fa61ca22656c21c7abade57b3925bb8329f2
@@ -19680,6 +19908,7 @@
 ./packages/api-utils/tests/test-hidden-frame.js 1.9b2 13c2a21f1f1a8e5dec2157a1fb7b3bc959c736fb7c05cd3a63ab019639fd7e43
 ./packages/api-utils/tests/test-hidden-frame.js 1.9b3 13c2a21f1f1a8e5dec2157a1fb7b3bc959c736fb7c05cd3a63ab019639fd7e43
 ./packages/api-utils/tests/test-hidden-frame.js 1.9-dev 70cea1e3f876854907cc77b05ee8948ac6a638bb6cbc365bb5e2ede758a42090
+./packages/api-utils/tests/test-hidden-frame.js 1.9rc1 13c2a21f1f1a8e5dec2157a1fb7b3bc959c736fb7c05cd3a63ab019639fd7e43
 ./packages/api-utils/tests/test-httpd.js 1.10-dev aa8b7abb927ab8e4582bdbba9dcaffffbbd23bb26c53861b22cf52a66c0293de
 ./packages/api-utils/tests/test-httpd.js 1.4.1 c357ac8bf6bd70a2a0489fb5fb61404825833ab43d323156ba808d5d9a696a6c
 ./packages/api-utils/tests/test-httpd.js 1.4.2 c357ac8bf6bd70a2a0489fb5fb61404825833ab43d323156ba808d5d9a696a6c
@@ -19728,6 +19957,7 @@
 ./packages/api-utils/tests/test-httpd.js 1.9b2 aa8b7abb927ab8e4582bdbba9dcaffffbbd23bb26c53861b22cf52a66c0293de
 ./packages/api-utils/tests/test-httpd.js 1.9b3 aa8b7abb927ab8e4582bdbba9dcaffffbbd23bb26c53861b22cf52a66c0293de
 ./packages/api-utils/tests/test-httpd.js 1.9-dev aa8b7abb927ab8e4582bdbba9dcaffffbbd23bb26c53861b22cf52a66c0293de
+./packages/api-utils/tests/test-httpd.js 1.9rc1 aa8b7abb927ab8e4582bdbba9dcaffffbbd23bb26c53861b22cf52a66c0293de
 ./packages/api-utils/tests/test-keyboard-observer.js 1.10-dev d4828c7989df6d14be1d2f0b12806b18c1e834ea1cce92d8ef991cd21111dcba
 ./packages/api-utils/tests/test-keyboard-observer.js 1.1 955d4942eb951abac54085ac6e9a63602141bc5f47ae1c2da0c4a84a2aa37e56
 ./packages/api-utils/tests/test-keyboard-observer.js 1.1a1 955d4942eb951abac54085ac6e9a63602141bc5f47ae1c2da0c4a84a2aa37e56
@@ -19795,6 +20025,7 @@
 ./packages/api-utils/tests/test-keyboard-observer.js 1.9b2 d4828c7989df6d14be1d2f0b12806b18c1e834ea1cce92d8ef991cd21111dcba
 ./packages/api-utils/tests/test-keyboard-observer.js 1.9b3 d4828c7989df6d14be1d2f0b12806b18c1e834ea1cce92d8ef991cd21111dcba
 ./packages/api-utils/tests/test-keyboard-observer.js 1.9-dev d9e63e1714c1ca86766ae0bbf4c3af87a21d539b5af9c6f7c88cff72835921b3
+./packages/api-utils/tests/test-keyboard-observer.js 1.9rc1 d4828c7989df6d14be1d2f0b12806b18c1e834ea1cce92d8ef991cd21111dcba
 ./packages/api-utils/tests/test-keyboard-utils.js 1.0b5 d0dfe98bffa851b9494f387c7242f3b1cf4e6dccbd75f8d255dbf264f78e8eec
 ./packages/api-utils/tests/test-keyboard-utils.js 1.0b5rc1 d0dfe98bffa851b9494f387c7242f3b1cf4e6dccbd75f8d255dbf264f78e8eec
 ./packages/api-utils/tests/test-keyboard-utils.js 1.0b5rc2 d0dfe98bffa851b9494f387c7242f3b1cf4e6dccbd75f8d255dbf264f78e8eec
@@ -19870,6 +20101,7 @@
 ./packages/api-utils/tests/test-keyboard-utils.js 1.9b2 dd72d9cbfb3752689b12126f7ee9f54b30e2f2fed866c0d248ce878a4990e34b
 ./packages/api-utils/tests/test-keyboard-utils.js 1.9b3 dd72d9cbfb3752689b12126f7ee9f54b30e2f2fed866c0d248ce878a4990e34b
 ./packages/api-utils/tests/test-keyboard-utils.js 1.9-dev dd72d9cbfb3752689b12126f7ee9f54b30e2f2fed866c0d248ce878a4990e34b
+./packages/api-utils/tests/test-keyboard-utils.js 1.9rc1 dd72d9cbfb3752689b12126f7ee9f54b30e2f2fed866c0d248ce878a4990e34b
 ./packages/api-utils/tests/test-l10n-locale.js 1.10-dev ffba0700a654310e15012f290b5c01d76d09c06bd3ecb90da72601213b960ab2
 ./packages/api-utils/tests/test-l10n-locale.js 1.6.1 ffba0700a654310e15012f290b5c01d76d09c06bd3ecb90da72601213b960ab2
 ./packages/api-utils/tests/test-l10n-locale.js 1.6.1rc1 ffba0700a654310e15012f290b5c01d76d09c06bd3ecb90da72601213b960ab2
@@ -19898,6 +20130,7 @@
 ./packages/api-utils/tests/test-l10n-locale.js 1.9b2 ffba0700a654310e15012f290b5c01d76d09c06bd3ecb90da72601213b960ab2
 ./packages/api-utils/tests/test-l10n-locale.js 1.9b3 ffba0700a654310e15012f290b5c01d76d09c06bd3ecb90da72601213b960ab2
 ./packages/api-utils/tests/test-l10n-locale.js 1.9-dev ffba0700a654310e15012f290b5c01d76d09c06bd3ecb90da72601213b960ab2
+./packages/api-utils/tests/test-l10n-locale.js 1.9rc1 ffba0700a654310e15012f290b5c01d76d09c06bd3ecb90da72601213b960ab2
 ./packages/api-utils/tests/test-l10n-plural-rules.js 1.10-dev 380b7bd8a05cd99e61adc9c2f85aeb09233feaebab0d4f76425996f96ee9067c
 ./packages/api-utils/tests/test-l10n-plural-rules.js 1.7 380b7bd8a05cd99e61adc9c2f85aeb09233feaebab0d4f76425996f96ee9067c
 ./packages/api-utils/tests/test-l10n-plural-rules.js 1.7b1 380b7bd8a05cd99e61adc9c2f85aeb09233feaebab0d4f76425996f96ee9067c
@@ -19918,6 +20151,7 @@
 ./packages/api-utils/tests/test-l10n-plural-rules.js 1.9b2 380b7bd8a05cd99e61adc9c2f85aeb09233feaebab0d4f76425996f96ee9067c
 ./packages/api-utils/tests/test-l10n-plural-rules.js 1.9b3 380b7bd8a05cd99e61adc9c2f85aeb09233feaebab0d4f76425996f96ee9067c
 ./packages/api-utils/tests/test-l10n-plural-rules.js 1.9-dev 380b7bd8a05cd99e61adc9c2f85aeb09233feaebab0d4f76425996f96ee9067c
+./packages/api-utils/tests/test-l10n-plural-rules.js 1.9rc1 380b7bd8a05cd99e61adc9c2f85aeb09233feaebab0d4f76425996f96ee9067c
 ./packages/api-utils/tests/test-light-traits.js 1.0 12059dc2c2a49fc6977a1c13f6a7e5f9131e84714b1e1f0fa3450cb5522e0b58
 ./packages/api-utils/tests/test-light-traits.js 1.0b3 12059dc2c2a49fc6977a1c13f6a7e5f9131e84714b1e1f0fa3450cb5522e0b58
 ./packages/api-utils/tests/test-light-traits.js 1.0b3rc1 12059dc2c2a49fc6977a1c13f6a7e5f9131e84714b1e1f0fa3450cb5522e0b58
@@ -20002,6 +20236,7 @@
 ./packages/api-utils/tests/test-light-traits.js 1.9b2 213b1f6306f450edab64c1a3d1469fc4e7554ce113d21533c87cab32020f7398
 ./packages/api-utils/tests/test-light-traits.js 1.9b3 213b1f6306f450edab64c1a3d1469fc4e7554ce113d21533c87cab32020f7398
 ./packages/api-utils/tests/test-light-traits.js 1.9-dev 213b1f6306f450edab64c1a3d1469fc4e7554ce113d21533c87cab32020f7398
+./packages/api-utils/tests/test-light-traits.js 1.9rc1 213b1f6306f450edab64c1a3d1469fc4e7554ce113d21533c87cab32020f7398
 ./packages/api-utils/tests/test-list.js 1.0 2fc2de064a56e9545cf42c08b1306400639b24d824976adc6f58ab18f78c7265
 ./packages/api-utils/tests/test-list.js 1.0b1 91029af0832ab8162d862948dcf8cade95a72c3ed0b14ebac3973edfe93a085a
 ./packages/api-utils/tests/test-list.js 1.0b1rc1 91029af0832ab8162d862948dcf8cade95a72c3ed0b14ebac3973edfe93a085a
@@ -20093,6 +20328,7 @@
 ./packages/api-utils/tests/test-list.js 1.9b2 3d3045af7ae191b47985f165055e14e4350eadb3b15db5d2a73c02d3f07ce8ef
 ./packages/api-utils/tests/test-list.js 1.9b3 3d3045af7ae191b47985f165055e14e4350eadb3b15db5d2a73c02d3f07ce8ef
 ./packages/api-utils/tests/test-list.js 1.9-dev 3d3045af7ae191b47985f165055e14e4350eadb3b15db5d2a73c02d3f07ce8ef
+./packages/api-utils/tests/test-list.js 1.9rc1 3d3045af7ae191b47985f165055e14e4350eadb3b15db5d2a73c02d3f07ce8ef
 ./packages/api-utils/tests/test-loader.js 1.10-dev d859e909786aa38a5a549a8db17479973fc9b871ca1adca60b9a894bd520c54e
 ./packages/api-utils/tests/test-loader.js 1.4.1 d6a79a89f4c97d690af73e8d20bbb4078f3331999d7e69bb24e783aeaa2cd61d
 ./packages/api-utils/tests/test-loader.js 1.4.2 d6a79a89f4c97d690af73e8d20bbb4078f3331999d7e69bb24e783aeaa2cd61d
@@ -20141,6 +20377,7 @@
 ./packages/api-utils/tests/test-loader.js 1.9b2 d859e909786aa38a5a549a8db17479973fc9b871ca1adca60b9a894bd520c54e
 ./packages/api-utils/tests/test-loader.js 1.9b3 d859e909786aa38a5a549a8db17479973fc9b871ca1adca60b9a894bd520c54e
 ./packages/api-utils/tests/test-loader.js 1.9-dev 22a3f33233341f509a0ae1a68161e302b83c6b075000273aef67988b65e8ce8f
+./packages/api-utils/tests/test-loader.js 1.9rc1 a0cc60df3a1a9f5b81467c435f4df680f4d80f91517842e587b781d64658a764
 ./packages/api-utils/tests/test-manifest.js 1.0b1 acd81ec682fa7568bc987f9900a4c5d364166589d39c8d0b387b5cc65ab4e108
 ./packages/api-utils/tests/test-manifest.js 1.0b1rc1 acd81ec682fa7568bc987f9900a4c5d364166589d39c8d0b387b5cc65ab4e108
 ./packages/api-utils/tests/test-manifest.js 1.0b1rc2 acd81ec682fa7568bc987f9900a4c5d364166589d39c8d0b387b5cc65ab4e108
@@ -20248,6 +20485,7 @@
 ./packages/api-utils/tests/test-match-pattern.js 1.9b2 124facbe1a73269def508360ccbd59048f47cfa8615b3f15c959aac78b19a46e
 ./packages/api-utils/tests/test-match-pattern.js 1.9b3 124facbe1a73269def508360ccbd59048f47cfa8615b3f15c959aac78b19a46e
 ./packages/api-utils/tests/test-match-pattern.js 1.9-dev 124facbe1a73269def508360ccbd59048f47cfa8615b3f15c959aac78b19a46e
+./packages/api-utils/tests/test-match-pattern.js 1.9rc1 124facbe1a73269def508360ccbd59048f47cfa8615b3f15c959aac78b19a46e
 ./packages/api-utils/tests/test-memory.js 1.0 1d7d29ec7bce284910b316325b361495fd78835d838f0adeddf25661510b7be9
 ./packages/api-utils/tests/test-memory.js 1.0b1 1d7d29ec7bce284910b316325b361495fd78835d838f0adeddf25661510b7be9
 ./packages/api-utils/tests/test-memory.js 1.0b1rc1 1d7d29ec7bce284910b316325b361495fd78835d838f0adeddf25661510b7be9
@@ -20339,6 +20577,7 @@
 ./packages/api-utils/tests/test-memory.js 1.9b2 51ae87916dbb864fe512b25376c806df1773308d7beb82208cb1051194f37e14
 ./packages/api-utils/tests/test-memory.js 1.9b3 51ae87916dbb864fe512b25376c806df1773308d7beb82208cb1051194f37e14
 ./packages/api-utils/tests/test-memory.js 1.9-dev 51ae87916dbb864fe512b25376c806df1773308d7beb82208cb1051194f37e14
+./packages/api-utils/tests/test-memory.js 1.9rc1 51ae87916dbb864fe512b25376c806df1773308d7beb82208cb1051194f37e14
 ./packages/api-utils/tests/test-message-manager.js 1.5 35b232d5d044ac927b0b7975573e2fcc1f0eec4ce961a5deea14f31f35300c7e
 ./packages/api-utils/tests/test-message-manager.js 1.5b1 35b232d5d044ac927b0b7975573e2fcc1f0eec4ce961a5deea14f31f35300c7e
 ./packages/api-utils/tests/test-message-manager.js 1.5b2 35b232d5d044ac927b0b7975573e2fcc1f0eec4ce961a5deea14f31f35300c7e
@@ -20446,6 +20685,7 @@
 ./packages/api-utils/tests/test-modules.js 1.9b2 8606510b0ae8035738f086366dce74ee2fe502c4f1b07af4b6ac0283a7f9496e
 ./packages/api-utils/tests/test-modules.js 1.9b3 8606510b0ae8035738f086366dce74ee2fe502c4f1b07af4b6ac0283a7f9496e
 ./packages/api-utils/tests/test-modules.js 1.9-dev 8606510b0ae8035738f086366dce74ee2fe502c4f1b07af4b6ac0283a7f9496e
+./packages/api-utils/tests/test-modules.js 1.9rc1 8606510b0ae8035738f086366dce74ee2fe502c4f1b07af4b6ac0283a7f9496e
 ./packages/api-utils/tests/test-namespace.js 1.10-dev fdb162b991918753c74c44cfe42a9b459654e39ae4e68ce3aa2b484f6c6d26be
 ./packages/api-utils/tests/test-namespace.js 1.4 10ea741f7a4f0463b220322bfc86a564e4ad8535fe1537e19736c5f38bc9db75
 ./packages/api-utils/tests/test-namespace.js 1.4.1 10ea741f7a4f0463b220322bfc86a564e4ad8535fe1537e19736c5f38bc9db75
@@ -20494,6 +20734,7 @@
 ./packages/api-utils/tests/test-namespace.js 1.9b2 fdb162b991918753c74c44cfe42a9b459654e39ae4e68ce3aa2b484f6c6d26be
 ./packages/api-utils/tests/test-namespace.js 1.9b3 fdb162b991918753c74c44cfe42a9b459654e39ae4e68ce3aa2b484f6c6d26be
 ./packages/api-utils/tests/test-namespace.js 1.9-dev 22667f2d32df08f40b9ec6415b667bdc3d442bf5c758e8462d3dcb3d311bf456
+./packages/api-utils/tests/test-namespace.js 1.9rc1 fdb162b991918753c74c44cfe42a9b459654e39ae4e68ce3aa2b484f6c6d26be
 ./packages/api-utils/tests/test-observer-service.js 1.0b1 b44e51acc033678ef288cc71440ef47c2ebe92f7a755cff49120b015da56ffd1
 ./packages/api-utils/tests/test-observer-service.js 1.0b1rc1 b44e51acc033678ef288cc71440ef47c2ebe92f7a755cff49120b015da56ffd1
 ./packages/api-utils/tests/test-observer-service.js 1.0b1rc2 b44e51acc033678ef288cc71440ef47c2ebe92f7a755cff49120b015da56ffd1
@@ -20585,6 +20826,7 @@
 ./packages/api-utils/tests/test-observer-service.js 1.9b2 99aa3c4c3d3d5bc0bfa6c6a384ebf857e6a61b43de79c8a3e6a876d056079651
 ./packages/api-utils/tests/test-observer-service.js 1.9b3 99aa3c4c3d3d5bc0bfa6c6a384ebf857e6a61b43de79c8a3e6a876d056079651
 ./packages/api-utils/tests/test-observer-service.js 1.9-dev 99aa3c4c3d3d5bc0bfa6c6a384ebf857e6a61b43de79c8a3e6a876d056079651
+./packages/api-utils/tests/test-observer-service.js 1.9rc1 99aa3c4c3d3d5bc0bfa6c6a384ebf857e6a61b43de79c8a3e6a876d056079651
 ./packages/api-utils/tests/test-passwords.js 1.0b4.1 8d64676391c5e862375d72bd8333f3970e7ea3263c03fb12efe9f1b44244d181
 ./packages/api-utils/tests/test-passwords.js 1.0b4 8d64676391c5e862375d72bd8333f3970e7ea3263c03fb12efe9f1b44244d181
 ./packages/api-utils/tests/test-passwords.js 1.0b4rc1 8d64676391c5e862375d72bd8333f3970e7ea3263c03fb12efe9f1b44244d181
@@ -20665,6 +20907,7 @@
 ./packages/api-utils/tests/test-passwords-utils.js 1.9b2 616d374a37f2db1794fe8dba74abec99be915e685c0fe801babfa6a32c69882c
 ./packages/api-utils/tests/test-passwords-utils.js 1.9b3 616d374a37f2db1794fe8dba74abec99be915e685c0fe801babfa6a32c69882c
 ./packages/api-utils/tests/test-passwords-utils.js 1.9-dev 616d374a37f2db1794fe8dba74abec99be915e685c0fe801babfa6a32c69882c
+./packages/api-utils/tests/test-passwords-utils.js 1.9rc1 616d374a37f2db1794fe8dba74abec99be915e685c0fe801babfa6a32c69882c
 ./packages/api-utils/tests/test-plain-text-console.js 1.0 4c3ed99d6c9c6bd57baf150c49cba3faa4b231e8b3c411ad579a010069e1c486
 ./packages/api-utils/tests/test-plain-text-console.js 1.0b1 4c3ed99d6c9c6bd57baf150c49cba3faa4b231e8b3c411ad579a010069e1c486
 ./packages/api-utils/tests/test-plain-text-console.js 1.0b1rc1 4c3ed99d6c9c6bd57baf150c49cba3faa4b231e8b3c411ad579a010069e1c486
@@ -20756,6 +20999,7 @@
 ./packages/api-utils/tests/test-plain-text-console.js 1.9b2 d89017a2b194da6fd91d5bcd2732fe179e24705806c94259fb9a05176823d086
 ./packages/api-utils/tests/test-plain-text-console.js 1.9b3 d89017a2b194da6fd91d5bcd2732fe179e24705806c94259fb9a05176823d086
 ./packages/api-utils/tests/test-plain-text-console.js 1.9-dev d89017a2b194da6fd91d5bcd2732fe179e24705806c94259fb9a05176823d086
+./packages/api-utils/tests/test-plain-text-console.js 1.9rc1 d89017a2b194da6fd91d5bcd2732fe179e24705806c94259fb9a05176823d086
 ./packages/api-utils/tests/test-preferences-service.js 1.0 77129e114914fab7b98e163f0302cf80fd9d44403f5b35f68c3db18c807280cd
 ./packages/api-utils/tests/test-preferences-service.js 1.0b1 b3d2c8fdf0da1da0bf66b38a261df0e9acc28c4eeb767f823ec5f1e6525384fd
 ./packages/api-utils/tests/test-preferences-service.js 1.0b1rc1 b3d2c8fdf0da1da0bf66b38a261df0e9acc28c4eeb767f823ec5f1e6525384fd
@@ -20847,6 +21091,7 @@
 ./packages/api-utils/tests/test-preferences-service.js 1.9b2 21a0962b1d24991b4da234eca31e4edaa776f109f914886180acb4555075532d
 ./packages/api-utils/tests/test-preferences-service.js 1.9b3 21a0962b1d24991b4da234eca31e4edaa776f109f914886180acb4555075532d
 ./packages/api-utils/tests/test-preferences-service.js 1.9-dev ffffad981b6d1cd11fbe19ac8c256594650c03bb6ad638854dfb2b2203553c56
+./packages/api-utils/tests/test-preferences-service.js 1.9rc1 21a0962b1d24991b4da234eca31e4edaa776f109f914886180acb4555075532d
 ./packages/api-utils/tests/test-process.js 1.6.1 1ca521b3e9ca8a1d06c27b94c3c8d1bc4a80077f54b8e0717ef1f6a5a244abf9
 ./packages/api-utils/tests/test-process.js 1.6 1ca521b3e9ca8a1d06c27b94c3c8d1bc4a80077f54b8e0717ef1f6a5a244abf9
 ./packages/api-utils/tests/test-process.js 1.6.1rc1 1ca521b3e9ca8a1d06c27b94c3c8d1bc4a80077f54b8e0717ef1f6a5a244abf9
@@ -20881,6 +21126,7 @@
 ./packages/api-utils/tests/test-promise.js 1.9b2 57d9e0767e4475fb3147b7962e6c47968dc545a1ed3e50b8883ab8f899a78b56
 ./packages/api-utils/tests/test-promise.js 1.9b3 57d9e0767e4475fb3147b7962e6c47968dc545a1ed3e50b8883ab8f899a78b56
 ./packages/api-utils/tests/test-promise.js 1.9-dev 57d9e0767e4475fb3147b7962e6c47968dc545a1ed3e50b8883ab8f899a78b56
+./packages/api-utils/tests/test-promise.js 1.9rc1 57d9e0767e4475fb3147b7962e6c47968dc545a1ed3e50b8883ab8f899a78b56
 ./packages/api-utils/tests/test-querystring.js 1.10-dev cfcb4ae8fbac5009dcddbd5cfe95e764b76d9410fc4a1ca4240dadf5f1344ed5
 ./packages/api-utils/tests/test-querystring.js 1.7b1 cfcb4ae8fbac5009dcddbd5cfe95e764b76d9410fc4a1ca4240dadf5f1344ed5
 ./packages/api-utils/tests/test-querystring.js 1.7b2 cfcb4ae8fbac5009dcddbd5cfe95e764b76d9410fc4a1ca4240dadf5f1344ed5
@@ -20901,6 +21147,7 @@
 ./packages/api-utils/tests/test-querystring.js 1.9b2 cfcb4ae8fbac5009dcddbd5cfe95e764b76d9410fc4a1ca4240dadf5f1344ed5
 ./packages/api-utils/tests/test-querystring.js 1.9b3 cfcb4ae8fbac5009dcddbd5cfe95e764b76d9410fc4a1ca4240dadf5f1344ed5
 ./packages/api-utils/tests/test-querystring.js 1.9-dev cfcb4ae8fbac5009dcddbd5cfe95e764b76d9410fc4a1ca4240dadf5f1344ed5
+./packages/api-utils/tests/test-querystring.js 1.9rc1 cfcb4ae8fbac5009dcddbd5cfe95e764b76d9410fc4a1ca4240dadf5f1344ed5
 ./packages/api-utils/tests/test-registry.js 1.0 37a515a40c7b28836b0004920c5bedfed2b53c6b6c0f6609ff5e6669a149383a
 ./packages/api-utils/tests/test-registry.js 1.0b1 37a515a40c7b28836b0004920c5bedfed2b53c6b6c0f6609ff5e6669a149383a
 ./packages/api-utils/tests/test-registry.js 1.0b1rc1 37a515a40c7b28836b0004920c5bedfed2b53c6b6c0f6609ff5e6669a149383a
@@ -20992,6 +21239,7 @@
 ./packages/api-utils/tests/test-registry.js 1.9b2 c13213e13fe88f17e5f4ef5af245e7e9d1af13c13a1003ce01cdc77b37e2ac29
 ./packages/api-utils/tests/test-registry.js 1.9b3 c13213e13fe88f17e5f4ef5af245e7e9d1af13c13a1003ce01cdc77b37e2ac29
 ./packages/api-utils/tests/test-registry.js 1.9-dev c13213e13fe88f17e5f4ef5af245e7e9d1af13c13a1003ce01cdc77b37e2ac29
+./packages/api-utils/tests/test-registry.js 1.9rc1 c13213e13fe88f17e5f4ef5af245e7e9d1af13c13a1003ce01cdc77b37e2ac29
 ./packages/api-utils/tests/test-require.js 1.10-dev e6de6091fa5f539c920e83d37376f474d8f2bd51710a4a1209dfeaa994ec2a47
 ./packages/api-utils/tests/test-require.js 1.2.1 32b9efa8fc2919afd174efc9fe9e64b521d49919d53170f93f798ea2b00268f4
 ./packages/api-utils/tests/test-require.js 1.2.1rc1 32b9efa8fc2919afd174efc9fe9e64b521d49919d53170f93f798ea2b00268f4
@@ -21053,6 +21301,7 @@
 ./packages/api-utils/tests/test-require.js 1.9b2 e6de6091fa5f539c920e83d37376f474d8f2bd51710a4a1209dfeaa994ec2a47
 ./packages/api-utils/tests/test-require.js 1.9b3 e6de6091fa5f539c920e83d37376f474d8f2bd51710a4a1209dfeaa994ec2a47
 ./packages/api-utils/tests/test-require.js 1.9-dev e6de6091fa5f539c920e83d37376f474d8f2bd51710a4a1209dfeaa994ec2a47
+./packages/api-utils/tests/test-require.js 1.9rc1 e6de6091fa5f539c920e83d37376f474d8f2bd51710a4a1209dfeaa994ec2a47
 ./packages/api-utils/tests/test-sandbox.js 1.10-dev 9d15574a7883b26ba7e7ed0c8728eb9ad41c60f2a16d473dd813310f30a91aa1
 ./packages/api-utils/tests/test-sandbox.js 1.5b1 b23c7c63852dce2a89d6c7c0f2a266cda83edc0107a58669f4e1b3c78ffe66f8
 ./packages/api-utils/tests/test-sandbox.js 1.5 b23c7c63852dce2a89d6c7c0f2a266cda83edc0107a58669f4e1b3c78ffe66f8
@@ -21088,6 +21337,7 @@
 ./packages/api-utils/tests/test-sandbox.js 1.9b2 9d15574a7883b26ba7e7ed0c8728eb9ad41c60f2a16d473dd813310f30a91aa1
 ./packages/api-utils/tests/test-sandbox.js 1.9b3 9d15574a7883b26ba7e7ed0c8728eb9ad41c60f2a16d473dd813310f30a91aa1
 ./packages/api-utils/tests/test-sandbox.js 1.9-dev 9d15574a7883b26ba7e7ed0c8728eb9ad41c60f2a16d473dd813310f30a91aa1
+./packages/api-utils/tests/test-sandbox.js 1.9rc1 9d15574a7883b26ba7e7ed0c8728eb9ad41c60f2a16d473dd813310f30a91aa1
 ./packages/api-utils/tests/test-securable-module.js 1.0b1 f08bad6f7958ff2de5f5ec7a416d506233a8f68626efa3955bd0fd72ab506480
 ./packages/api-utils/tests/test-securable-module.js 1.0b1rc1 f08bad6f7958ff2de5f5ec7a416d506233a8f68626efa3955bd0fd72ab506480
 ./packages/api-utils/tests/test-securable-module.js 1.0b1rc2 f08bad6f7958ff2de5f5ec7a416d506233a8f68626efa3955bd0fd72ab506480
@@ -21222,6 +21472,7 @@
 ./packages/api-utils/tests/test-self.js 1.9b2 a6c7cbc96fdbe64b3b6ee2f27a6d5daffd9d2a2b77338fc02c3dccd28987039b
 ./packages/api-utils/tests/test-self.js 1.9b3 a6c7cbc96fdbe64b3b6ee2f27a6d5daffd9d2a2b77338fc02c3dccd28987039b
 ./packages/api-utils/tests/test-self.js 1.9-dev a6c7cbc96fdbe64b3b6ee2f27a6d5daffd9d2a2b77338fc02c3dccd28987039b
+./packages/api-utils/tests/test-self.js 1.9rc1 a6c7cbc96fdbe64b3b6ee2f27a6d5daffd9d2a2b77338fc02c3dccd28987039b
 ./packages/api-utils/tests/test-set-exports.js 1.0 4b767ae332316d59d1e2ab603fbe86a06cb16087ff108fedf4db5e9e006fe379
 ./packages/api-utils/tests/test-set-exports.js 1.0b2 129a59fd808231b444150c4f62b1d2027e571f1d4e76d6a61d6e5b2ff8ed88b1
 ./packages/api-utils/tests/test-set-exports.js 1.0b2rc1 129a59fd808231b444150c4f62b1d2027e571f1d4e76d6a61d6e5b2ff8ed88b1
@@ -21308,6 +21559,7 @@
 ./packages/api-utils/tests/test-set-exports.js 1.9b2 e52dfbc74f09247fd64dfa185ecd57fd871a2beb3c5fea7ad75942e8bf223a4a
 ./packages/api-utils/tests/test-set-exports.js 1.9b3 e52dfbc74f09247fd64dfa185ecd57fd871a2beb3c5fea7ad75942e8bf223a4a
 ./packages/api-utils/tests/test-set-exports.js 1.9-dev e52dfbc74f09247fd64dfa185ecd57fd871a2beb3c5fea7ad75942e8bf223a4a
+./packages/api-utils/tests/test-set-exports.js 1.9rc1 e52dfbc74f09247fd64dfa185ecd57fd871a2beb3c5fea7ad75942e8bf223a4a
 ./packages/api-utils/tests/test-tab-browser.js 1.0 aca7e0c25249a0f44a8e00338ea7ac1ef6481aa543647fde6c5cd5504acbfa6c
 ./packages/api-utils/tests/test-tab-browser.js 1.0b1 01ae02bbab7c80911cd44cafa6c360aaf04929f28de85a8828ef60920ca1faae
 ./packages/api-utils/tests/test-tab-browser.js 1.0b1rc1 01ae02bbab7c80911cd44cafa6c360aaf04929f28de85a8828ef60920ca1faae
@@ -21399,6 +21651,7 @@
 ./packages/api-utils/tests/test-tab-browser.js 1.9b2 23bc7df4adbafcd88088f95228ee231b8c74080474296c51226ac521bcb3ae0a
 ./packages/api-utils/tests/test-tab-browser.js 1.9b3 23bc7df4adbafcd88088f95228ee231b8c74080474296c51226ac521bcb3ae0a
 ./packages/api-utils/tests/test-tab-browser.js 1.9-dev 8507f32b034477ca9e290dab0d88184f083760c6a6bad4cade9e1646452ee940
+./packages/api-utils/tests/test-tab-browser.js 1.9rc1 23bc7df4adbafcd88088f95228ee231b8c74080474296c51226ac521bcb3ae0a
 ./packages/api-utils/tests/test-tab.js 1.0 4e522539a072d19bd7056b7164d254791a0a929c66a580d80c98495751710d89
 ./packages/api-utils/tests/test-tab.js 1.0b4.1 d21e3c27da7083dbf61727548655eb4abc75f0c5619ee42b53fdc777d54ef51d
 ./packages/api-utils/tests/test-tab.js 1.0b4 d21e3c27da7083dbf61727548655eb4abc75f0c5619ee42b53fdc777d54ef51d
@@ -21479,6 +21732,7 @@
 ./packages/api-utils/tests/test-tab.js 1.9b2 e503956b244aaee828a5b6c2b2b3ec18e0f8ce8c650cca2823065e42c2da88d6
 ./packages/api-utils/tests/test-tab.js 1.9b3 e503956b244aaee828a5b6c2b2b3ec18e0f8ce8c650cca2823065e42c2da88d6
 ./packages/api-utils/tests/test-tab.js 1.9-dev d2b7a8e016d9f956c1f51af6a8c04e63418d6da70d7f0fdd966e3a75badbe26c
+./packages/api-utils/tests/test-tab.js 1.9rc1 e503956b244aaee828a5b6c2b2b3ec18e0f8ce8c650cca2823065e42c2da88d6
 ./packages/api-utils/tests/test-tab-observer.js 1.10-dev ef941d790e0349df18c512f19f2baf427cf0c63273dd59fafb3dbf03047c3f1f
 ./packages/api-utils/tests/test-tab-observer.js 1.1 33aec178ffcc2f41c924d5e728d44c1c928e7ced3e111fdf0459d95c187bd4eb
 ./packages/api-utils/tests/test-tab-observer.js 1.1a1 33aec178ffcc2f41c924d5e728d44c1c928e7ced3e111fdf0459d95c187bd4eb
@@ -21546,6 +21800,7 @@
 ./packages/api-utils/tests/test-tab-observer.js 1.9b2 ef941d790e0349df18c512f19f2baf427cf0c63273dd59fafb3dbf03047c3f1f
 ./packages/api-utils/tests/test-tab-observer.js 1.9b3 ef941d790e0349df18c512f19f2baf427cf0c63273dd59fafb3dbf03047c3f1f
 ./packages/api-utils/tests/test-tab-observer.js 1.9-dev 4a8ef6293d10127186082b8abff373aa006e75cd9d8569fd02980ad69d43df27
+./packages/api-utils/tests/test-tab-observer.js 1.9rc1 ef941d790e0349df18c512f19f2baf427cf0c63273dd59fafb3dbf03047c3f1f
 ./packages/api-utils/tests/test-text-streams.js 1.0 7814909e51dbfaa5248fdf1ef87061f6e4e7c4919105a04d00b1b89fdb095616
 ./packages/api-utils/tests/test-text-streams.js 1.0b1 7814909e51dbfaa5248fdf1ef87061f6e4e7c4919105a04d00b1b89fdb095616
 ./packages/api-utils/tests/test-text-streams.js 1.0b1rc1 7814909e51dbfaa5248fdf1ef87061f6e4e7c4919105a04d00b1b89fdb095616
@@ -21637,6 +21892,7 @@
 ./packages/api-utils/tests/test-text-streams.js 1.9b2 2a1d29c0342debf38b31ad3c8c5ec6ec864c48db5c654e0035c75e9bb349ac17
 ./packages/api-utils/tests/test-text-streams.js 1.9b3 2a1d29c0342debf38b31ad3c8c5ec6ec864c48db5c654e0035c75e9bb349ac17
 ./packages/api-utils/tests/test-text-streams.js 1.9-dev 2a1d29c0342debf38b31ad3c8c5ec6ec864c48db5c654e0035c75e9bb349ac17
+./packages/api-utils/tests/test-text-streams.js 1.9rc1 2a1d29c0342debf38b31ad3c8c5ec6ec864c48db5c654e0035c75e9bb349ac17
 ./packages/api-utils/tests/test-timer.js 1.0 a60548f4073bd2e23fb8fc00ed140bb57bcc34d15186cf058ea59fe6cf3b8777
 ./packages/api-utils/tests/test-timer.js 1.0b1 a60548f4073bd2e23fb8fc00ed140bb57bcc34d15186cf058ea59fe6cf3b8777
 ./packages/api-utils/tests/test-timer.js 1.0b1rc1 a60548f4073bd2e23fb8fc00ed140bb57bcc34d15186cf058ea59fe6cf3b8777
@@ -21728,6 +21984,7 @@
 ./packages/api-utils/tests/test-timer.js 1.9b2 6837f909070308bf1908ae7acf8be506ca8b17234079ce4d6279cb811e5c40de
 ./packages/api-utils/tests/test-timer.js 1.9b3 6837f909070308bf1908ae7acf8be506ca8b17234079ce4d6279cb811e5c40de
 ./packages/api-utils/tests/test-timer.js 1.9-dev 6837f909070308bf1908ae7acf8be506ca8b17234079ce4d6279cb811e5c40de
+./packages/api-utils/tests/test-timer.js 1.9rc1 6837f909070308bf1908ae7acf8be506ca8b17234079ce4d6279cb811e5c40de
 ./packages/api-utils/tests/test-traceback.js 1.0b1 d08a1146419ee6cbf28ab783e8ce779b17473e235678f3f0393c19d0b9d39b4c
 ./packages/api-utils/tests/test-traceback.js 1.0b1rc1 d08a1146419ee6cbf28ab783e8ce779b17473e235678f3f0393c19d0b9d39b4c
 ./packages/api-utils/tests/test-traceback.js 1.0b1rc2 d08a1146419ee6cbf28ab783e8ce779b17473e235678f3f0393c19d0b9d39b4c
@@ -21819,6 +22076,7 @@
 ./packages/api-utils/tests/test-traceback.js 1.9b2 493cb211cad91c79fe031f7d1213de4958bef2fc402e41f78cfdfd387d3778b0
 ./packages/api-utils/tests/test-traceback.js 1.9b3 493cb211cad91c79fe031f7d1213de4958bef2fc402e41f78cfdfd387d3778b0
 ./packages/api-utils/tests/test-traceback.js 1.9-dev 493cb211cad91c79fe031f7d1213de4958bef2fc402e41f78cfdfd387d3778b0
+./packages/api-utils/tests/test-traceback.js 1.9rc1 493cb211cad91c79fe031f7d1213de4958bef2fc402e41f78cfdfd387d3778b0
 ./packages/api-utils/tests/test-traits-core.js 1.0b1 fcb288891892582a3b7ac19e4ecd0658565c3a7fb70c9fa5e2a0a7bd53db60fd
 ./packages/api-utils/tests/test-traits-core.js 1.0b1rc1 fcb288891892582a3b7ac19e4ecd0658565c3a7fb70c9fa5e2a0a7bd53db60fd
 ./packages/api-utils/tests/test-traits-core.js 1.0b1rc2 fcb288891892582a3b7ac19e4ecd0658565c3a7fb70c9fa5e2a0a7bd53db60fd
@@ -21910,6 +22168,7 @@
 ./packages/api-utils/tests/test-traits-core.js 1.9b2 ddafe3aad459fafc9f5da86bfae2cb511f6feb08aeb9bcc7a4f4a1c35d3931ca
 ./packages/api-utils/tests/test-traits-core.js 1.9b3 ddafe3aad459fafc9f5da86bfae2cb511f6feb08aeb9bcc7a4f4a1c35d3931ca
 ./packages/api-utils/tests/test-traits-core.js 1.9-dev ddafe3aad459fafc9f5da86bfae2cb511f6feb08aeb9bcc7a4f4a1c35d3931ca
+./packages/api-utils/tests/test-traits-core.js 1.9rc1 ddafe3aad459fafc9f5da86bfae2cb511f6feb08aeb9bcc7a4f4a1c35d3931ca
 ./packages/api-utils/tests/test-traits.js 1.0 ade687d89b0eb20117a662dcf00f43f1ae9b3b847302b008396749d9ebbaa179
 ./packages/api-utils/tests/test-traits.js 1.0b1 ade687d89b0eb20117a662dcf00f43f1ae9b3b847302b008396749d9ebbaa179
 ./packages/api-utils/tests/test-traits.js 1.0b1rc1 ade687d89b0eb20117a662dcf00f43f1ae9b3b847302b008396749d9ebbaa179
@@ -22001,6 +22260,7 @@
 ./packages/api-utils/tests/test-traits.js 1.9b2 3a3c676432a4371baf7b4ccfde0bdd865267eb9ec7b15c69f787b6ac7d66b53e
 ./packages/api-utils/tests/test-traits.js 1.9b3 3a3c676432a4371baf7b4ccfde0bdd865267eb9ec7b15c69f787b6ac7d66b53e
 ./packages/api-utils/tests/test-traits.js 1.9-dev 3a3c676432a4371baf7b4ccfde0bdd865267eb9ec7b15c69f787b6ac7d66b53e
+./packages/api-utils/tests/test-traits.js 1.9rc1 3a3c676432a4371baf7b4ccfde0bdd865267eb9ec7b15c69f787b6ac7d66b53e
 ./packages/api-utils/tests/test-type.js 1.0b3 e19fc2e00ae525915a9a340dedb6ab695cef3570d3e98b0898c7e721c96f8c79
 ./packages/api-utils/tests/test-type.js 1.0b3rc1 e19fc2e00ae525915a9a340dedb6ab695cef3570d3e98b0898c7e721c96f8c79
 ./packages/api-utils/tests/test-type.js 1.0b3rc2 e19fc2e00ae525915a9a340dedb6ab695cef3570d3e98b0898c7e721c96f8c79
@@ -22085,6 +22345,7 @@
 ./packages/api-utils/tests/test-type.js 1.9b2 0c7ad60b218ffb91fe17da9711a38dddc5a101699e80fb3549c2f85ca161af66
 ./packages/api-utils/tests/test-type.js 1.9b3 0c7ad60b218ffb91fe17da9711a38dddc5a101699e80fb3549c2f85ca161af66
 ./packages/api-utils/tests/test-type.js 1.9-dev 0c7ad60b218ffb91fe17da9711a38dddc5a101699e80fb3549c2f85ca161af66
+./packages/api-utils/tests/test-type.js 1.9rc1 0c7ad60b218ffb91fe17da9711a38dddc5a101699e80fb3549c2f85ca161af66
 ./packages/api-utils/tests/test-unit-test.js 1.0 0b7e4856094d88aa0d3ca95171a2f43abb5bfdcb9b3071f8b93ba53da0226c3e
 ./packages/api-utils/tests/test-unit-test.js 1.0b1 aa317884ff3345a8362064dba44bdc0ff34dece45b0724a60fb2346739238182
 ./packages/api-utils/tests/test-unit-test.js 1.0b1rc1 aa317884ff3345a8362064dba44bdc0ff34dece45b0724a60fb2346739238182
@@ -22176,6 +22437,7 @@
 ./packages/api-utils/tests/test-unit-test.js 1.9b2 78da631d4c3798edd0357773f068260daf1855176c13dd58f8445967a359579f
 ./packages/api-utils/tests/test-unit-test.js 1.9b3 78da631d4c3798edd0357773f068260daf1855176c13dd58f8445967a359579f
 ./packages/api-utils/tests/test-unit-test.js 1.9-dev 78da631d4c3798edd0357773f068260daf1855176c13dd58f8445967a359579f
+./packages/api-utils/tests/test-unit-test.js 1.9rc1 78da631d4c3798edd0357773f068260daf1855176c13dd58f8445967a359579f
 ./packages/api-utils/tests/test-unload.js 1.0 3a23fd38053b7ad66d1f22ccac312ff83baaa63124a14b4b710e200d1405cf32
 ./packages/api-utils/tests/test-unload.js 1.0b1 d66137f85e427eb74adbeaa1e2ffdeb24a7b3bd2fdb7fcb2b431b8d018d97657
 ./packages/api-utils/tests/test-unload.js 1.0b1rc1 d66137f85e427eb74adbeaa1e2ffdeb24a7b3bd2fdb7fcb2b431b8d018d97657
@@ -22267,6 +22529,7 @@
 ./packages/api-utils/tests/test-unload.js 1.9b2 8168e86be5f3aa9399072e0081d3eff66fed8ac8a7b919eb19929a2485d5d49a
 ./packages/api-utils/tests/test-unload.js 1.9b3 8168e86be5f3aa9399072e0081d3eff66fed8ac8a7b919eb19929a2485d5d49a
 ./packages/api-utils/tests/test-unload.js 1.9-dev 8168e86be5f3aa9399072e0081d3eff66fed8ac8a7b919eb19929a2485d5d49a
+./packages/api-utils/tests/test-unload.js 1.9rc1 8168e86be5f3aa9399072e0081d3eff66fed8ac8a7b919eb19929a2485d5d49a
 ./packages/api-utils/tests/test-url.js 1.0 8c5b6b3c1070ebc25af152a659acfb33cab773722ae27b389b43de6722738858
 ./packages/api-utils/tests/test-url.js 1.0b1 f6a07af01c5a2520c8431a78a4ddfdc633d45aafa254e835827774a4b4e1f228
 ./packages/api-utils/tests/test-url.js 1.0b1rc1 f6a07af01c5a2520c8431a78a4ddfdc633d45aafa254e835827774a4b4e1f228
@@ -22358,6 +22621,7 @@
 ./packages/api-utils/tests/test-url.js 1.9b2 3b29375e8b414ed41de2eaf155d7d7431220c2ebd239598fa11bb7629dfe24a9
 ./packages/api-utils/tests/test-url.js 1.9b3 3b29375e8b414ed41de2eaf155d7d7431220c2ebd239598fa11bb7629dfe24a9
 ./packages/api-utils/tests/test-url.js 1.9-dev 79688ff1436e9c651a0b0bf3e85a632577a17ac6810fbdeb7e2322c607f76931
+./packages/api-utils/tests/test-url.js 1.9rc1 3b29375e8b414ed41de2eaf155d7d7431220c2ebd239598fa11bb7629dfe24a9
 ./packages/api-utils/tests/test-uuid.js 1.10-dev 2a3ad0c33cd88b76efb179b4f98ff6d398b409cb9a8979b8c15faa6c71006c82
 ./packages/api-utils/tests/test-uuid.js 1.6.1 d72831b40252c7b891452db04e055563858c40e3431752f1b8256133d117e025
 ./packages/api-utils/tests/test-uuid.js 1.6.1rc1 d72831b40252c7b891452db04e055563858c40e3431752f1b8256133d117e025
@@ -22386,6 +22650,7 @@
 ./packages/api-utils/tests/test-uuid.js 1.9b2 2a3ad0c33cd88b76efb179b4f98ff6d398b409cb9a8979b8c15faa6c71006c82
 ./packages/api-utils/tests/test-uuid.js 1.9b3 2a3ad0c33cd88b76efb179b4f98ff6d398b409cb9a8979b8c15faa6c71006c82
 ./packages/api-utils/tests/test-uuid.js 1.9-dev 2a3ad0c33cd88b76efb179b4f98ff6d398b409cb9a8979b8c15faa6c71006c82
+./packages/api-utils/tests/test-uuid.js 1.9rc1 2a3ad0c33cd88b76efb179b4f98ff6d398b409cb9a8979b8c15faa6c71006c82
 ./packages/api-utils/tests/test-window-loader.js 1.0 95dc930d862ca04a8c7a35d7a80449f948860bf0ef1d924ee86800e09c912292
 ./packages/api-utils/tests/test-window-loader.js 1.0b1 95dc930d862ca04a8c7a35d7a80449f948860bf0ef1d924ee86800e09c912292
 ./packages/api-utils/tests/test-window-loader.js 1.0b1rc1 95dc930d862ca04a8c7a35d7a80449f948860bf0ef1d924ee86800e09c912292
@@ -22477,6 +22742,7 @@
 ./packages/api-utils/tests/test-window-loader.js 1.9b2 a5eda50a0574973a9f1457c8046f1ef9d41c88fd062e350ca8d7adf08927a957
 ./packages/api-utils/tests/test-window-loader.js 1.9b3 a5eda50a0574973a9f1457c8046f1ef9d41c88fd062e350ca8d7adf08927a957
 ./packages/api-utils/tests/test-window-loader.js 1.9-dev a5eda50a0574973a9f1457c8046f1ef9d41c88fd062e350ca8d7adf08927a957
+./packages/api-utils/tests/test-window-loader.js 1.9rc1 a5eda50a0574973a9f1457c8046f1ef9d41c88fd062e350ca8d7adf08927a957
 ./packages/api-utils/tests/test-window-observer.js 1.10-dev b59383b0185a9de024b3cd00cefebefa54c6e3e73c308d7e9ac67b781e129b6a
 ./packages/api-utils/tests/test-window-observer.js 1.1a1 c0cd8e839a9e758147a411941a03208448d2421ef92d217f730e457a3731bea8
 ./packages/api-utils/tests/test-window-observer.js 1.1a2 c0cd8e839a9e758147a411941a03208448d2421ef92d217f730e457a3731bea8
@@ -22544,6 +22810,7 @@
 ./packages/api-utils/tests/test-window-observer.js 1.9b2 b59383b0185a9de024b3cd00cefebefa54c6e3e73c308d7e9ac67b781e129b6a
 ./packages/api-utils/tests/test-window-observer.js 1.9b3 b59383b0185a9de024b3cd00cefebefa54c6e3e73c308d7e9ac67b781e129b6a
 ./packages/api-utils/tests/test-window-observer.js 1.9-dev da8a9d1782dd30da4dfbbe695b858fdc0acf37f592fae30172606afb5acaad2c
+./packages/api-utils/tests/test-window-observer.js 1.9rc1 b59383b0185a9de024b3cd00cefebefa54c6e3e73c308d7e9ac67b781e129b6a
 ./packages/api-utils/tests/test-window-utils2.js 1.10-dev 130ca32333057721e23b57515f443ed48f9797a5e8719e70c89d090ca9718ae1
 ./packages/api-utils/tests/test-window-utils2.js 1.7 1f7a3f2fb523a93fee08c5e3596dbbda48ec7e9d1de95d12506468f18c9c2d9a
 ./packages/api-utils/tests/test-window-utils2.js 1.7b1 1f7a3f2fb523a93fee08c5e3596dbbda48ec7e9d1de95d12506468f18c9c2d9a
@@ -22564,6 +22831,7 @@
 ./packages/api-utils/tests/test-window-utils2.js 1.9b2 130ca32333057721e23b57515f443ed48f9797a5e8719e70c89d090ca9718ae1
 ./packages/api-utils/tests/test-window-utils2.js 1.9b3 130ca32333057721e23b57515f443ed48f9797a5e8719e70c89d090ca9718ae1
 ./packages/api-utils/tests/test-window-utils2.js 1.9-dev 1f7a3f2fb523a93fee08c5e3596dbbda48ec7e9d1de95d12506468f18c9c2d9a
+./packages/api-utils/tests/test-window-utils2.js 1.9rc1 130ca32333057721e23b57515f443ed48f9797a5e8719e70c89d090ca9718ae1
 ./packages/api-utils/tests/test-window-utils.js 1.0b1 c07cadf1d7057648bac7978e8d1e02784ac3d9dbd7d63fc1efe532704ee75eac
 ./packages/api-utils/tests/test-window-utils.js 1.0b1rc1 c07cadf1d7057648bac7978e8d1e02784ac3d9dbd7d63fc1efe532704ee75eac
 ./packages/api-utils/tests/test-window-utils.js 1.0b1rc2 c07cadf1d7057648bac7978e8d1e02784ac3d9dbd7d63fc1efe532704ee75eac
@@ -22655,6 +22923,7 @@
 ./packages/api-utils/tests/test-window-utils.js 1.9b2 19da2213d85812c9ffaa4bcb2bb4617a8b708224b181773bbede82f0d7c8d186
 ./packages/api-utils/tests/test-window-utils.js 1.9b3 19da2213d85812c9ffaa4bcb2bb4617a8b708224b181773bbede82f0d7c8d186
 ./packages/api-utils/tests/test-window-utils.js 1.9-dev b468eb1c91cc6f013e433447ecfc5ee85cefed8415b888de115ac26039144480
+./packages/api-utils/tests/test-window-utils.js 1.9rc1 19da2213d85812c9ffaa4bcb2bb4617a8b708224b181773bbede82f0d7c8d186
 ./packages/api-utils/tests/test-xhr.js 1.0 2e41bb0adf1c5873c5bdc532ac493191c4d97b047925010400cb3057bf9418d8
 ./packages/api-utils/tests/test-xhr.js 1.0b1 2e41bb0adf1c5873c5bdc532ac493191c4d97b047925010400cb3057bf9418d8
 ./packages/api-utils/tests/test-xhr.js 1.0b1rc1 2e41bb0adf1c5873c5bdc532ac493191c4d97b047925010400cb3057bf9418d8
@@ -22746,6 +23015,7 @@
 ./packages/api-utils/tests/test-xhr.js 1.9b2 076de955b972529eefd1956d05c9fef27b1046fcc699c8da07982b0025e851a2
 ./packages/api-utils/tests/test-xhr.js 1.9b3 076de955b972529eefd1956d05c9fef27b1046fcc699c8da07982b0025e851a2
 ./packages/api-utils/tests/test-xhr.js 1.9-dev 076de955b972529eefd1956d05c9fef27b1046fcc699c8da07982b0025e851a2
+./packages/api-utils/tests/test-xhr.js 1.9rc1 076de955b972529eefd1956d05c9fef27b1046fcc699c8da07982b0025e851a2
 ./packages/api-utils/tests/test-xpcom.js 1.0 2f4c2656024f2b7becfb709493e2a43cd30aeb5b85b2ec7c7b7225145bfece30
 ./packages/api-utils/tests/test-xpcom.js 1.0b1 a03d08bc0a19f507e5caa5bba50faa4b4220d278a7b1ea992dc5627d1412d4b4
 ./packages/api-utils/tests/test-xpcom.js 1.0b1rc1 a03d08bc0a19f507e5caa5bba50faa4b4220d278a7b1ea992dc5627d1412d4b4
@@ -22837,6 +23107,7 @@
 ./packages/api-utils/tests/test-xpcom.js 1.9b2 27b01cefb2b5a000477385514ca02426b35cb2d645a48eb45419c2859c2e6d59
 ./packages/api-utils/tests/test-xpcom.js 1.9b3 27b01cefb2b5a000477385514ca02426b35cb2d645a48eb45419c2859c2e6d59
 ./packages/api-utils/tests/test-xpcom.js 1.9-dev 472f6313bf395df39ee6fe92b61ac6a95e06c8019d33c452085db5180c379ca6
+./packages/api-utils/tests/test-xpcom.js 1.9rc1 27b01cefb2b5a000477385514ca02426b35cb2d645a48eb45419c2859c2e6d59
 ./packages/api-utils/tests/test-xul-app.js 1.0 704435c3b42c8f1d7db8699d86b3c6f9d120771dfdf2808bb817a5e7a04c2353
 ./packages/api-utils/tests/test-xul-app.js 1.0b1 704435c3b42c8f1d7db8699d86b3c6f9d120771dfdf2808bb817a5e7a04c2353
 ./packages/api-utils/tests/test-xul-app.js 1.0b1rc1 704435c3b42c8f1d7db8699d86b3c6f9d120771dfdf2808bb817a5e7a04c2353
@@ -22928,6 +23199,7 @@
 ./packages/api-utils/tests/test-xul-app.js 1.9b2 9c6884bf98ac657885b8037864894dee3bdda57c2ee41ecd07ddce4f372545b0
 ./packages/api-utils/tests/test-xul-app.js 1.9b3 9c6884bf98ac657885b8037864894dee3bdda57c2ee41ecd07ddce4f372545b0
 ./packages/api-utils/tests/test-xul-app.js 1.9-dev 9c6884bf98ac657885b8037864894dee3bdda57c2ee41ecd07ddce4f372545b0
+./packages/api-utils/tests/test-xul-app.js 1.9rc1 9c6884bf98ac657885b8037864894dee3bdda57c2ee41ecd07ddce4f372545b0
 ./packages/api-utils/tests/traits/assert.js 1.0 878f70d443d7a5fb07d735b1dedec5d0e36ffb5e0fd5ee8bdca8dddd3e888f4c
 ./packages/api-utils/tests/traits/assert.js 1.0b3 878f70d443d7a5fb07d735b1dedec5d0e36ffb5e0fd5ee8bdca8dddd3e888f4c
 ./packages/api-utils/tests/traits/assert.js 1.0b3rc1 878f70d443d7a5fb07d735b1dedec5d0e36ffb5e0fd5ee8bdca8dddd3e888f4c
@@ -23012,6 +23284,7 @@
 ./packages/api-utils/tests/traits/assert.js 1.9b2 a2fbca11a28bace48213a264a721cfbb4565084b4a299cd27c339cef3d23f5f0
 ./packages/api-utils/tests/traits/assert.js 1.9b3 a2fbca11a28bace48213a264a721cfbb4565084b4a299cd27c339cef3d23f5f0
 ./packages/api-utils/tests/traits/assert.js 1.9-dev a2fbca11a28bace48213a264a721cfbb4565084b4a299cd27c339cef3d23f5f0
+./packages/api-utils/tests/traits/assert.js 1.9rc1 a2fbca11a28bace48213a264a721cfbb4565084b4a299cd27c339cef3d23f5f0
 ./packages/api-utils/tests/traits/descriptor-tests.js 1.0 a80ec7950f97d5fb337d05d77ada13b81f772a7b52f1c99a3941f106c1c2da4c
 ./packages/api-utils/tests/traits/descriptor-tests.js 1.0b3 a80ec7950f97d5fb337d05d77ada13b81f772a7b52f1c99a3941f106c1c2da4c
 ./packages/api-utils/tests/traits/descriptor-tests.js 1.0b3rc1 a80ec7950f97d5fb337d05d77ada13b81f772a7b52f1c99a3941f106c1c2da4c
@@ -23096,6 +23369,7 @@
 ./packages/api-utils/tests/traits/descriptor-tests.js 1.9b2 4fd671d41a816f84633ec77080180b61352b9e882955363f4593e83d699330e6
 ./packages/api-utils/tests/traits/descriptor-tests.js 1.9b3 4fd671d41a816f84633ec77080180b61352b9e882955363f4593e83d699330e6
 ./packages/api-utils/tests/traits/descriptor-tests.js 1.9-dev 4fd671d41a816f84633ec77080180b61352b9e882955363f4593e83d699330e6
+./packages/api-utils/tests/traits/descriptor-tests.js 1.9rc1 4fd671d41a816f84633ec77080180b61352b9e882955363f4593e83d699330e6
 ./packages/api-utils/tests/traits/inheritance-tests.js 1.0 85e0520b68782648bc41ce891525d3d89f17eabfa6af4922570c70bc628c607c
 ./packages/api-utils/tests/traits/inheritance-tests.js 1.0b3 85e0520b68782648bc41ce891525d3d89f17eabfa6af4922570c70bc628c607c
 ./packages/api-utils/tests/traits/inheritance-tests.js 1.0b3rc1 85e0520b68782648bc41ce891525d3d89f17eabfa6af4922570c70bc628c607c
@@ -23180,6 +23454,7 @@
 ./packages/api-utils/tests/traits/inheritance-tests.js 1.9b2 7ef1f317f7ba80073a67cca8499784ee63b9952a3b6f0ed9a68a929226ffc2d2
 ./packages/api-utils/tests/traits/inheritance-tests.js 1.9b3 7ef1f317f7ba80073a67cca8499784ee63b9952a3b6f0ed9a68a929226ffc2d2
 ./packages/api-utils/tests/traits/inheritance-tests.js 1.9-dev 7ef1f317f7ba80073a67cca8499784ee63b9952a3b6f0ed9a68a929226ffc2d2
+./packages/api-utils/tests/traits/inheritance-tests.js 1.9rc1 7ef1f317f7ba80073a67cca8499784ee63b9952a3b6f0ed9a68a929226ffc2d2
 ./packages/api-utils/tests/traits/object-tests.js 1.0 0c0af6a7f0ff6f9a0326c074ced7748709db38914f1f6e2bc57d62f6836e2994
 ./packages/api-utils/tests/traits/object-tests.js 1.0b3 0c0af6a7f0ff6f9a0326c074ced7748709db38914f1f6e2bc57d62f6836e2994
 ./packages/api-utils/tests/traits/object-tests.js 1.0b3rc1 0c0af6a7f0ff6f9a0326c074ced7748709db38914f1f6e2bc57d62f6836e2994
@@ -23264,6 +23539,7 @@
 ./packages/api-utils/tests/traits/object-tests.js 1.9b2 69760858a8954017327471545edae4df8fd44d6034d872d04cd0e456b4b79a65
 ./packages/api-utils/tests/traits/object-tests.js 1.9b3 69760858a8954017327471545edae4df8fd44d6034d872d04cd0e456b4b79a65
 ./packages/api-utils/tests/traits/object-tests.js 1.9-dev 69760858a8954017327471545edae4df8fd44d6034d872d04cd0e456b4b79a65
+./packages/api-utils/tests/traits/object-tests.js 1.9rc1 69760858a8954017327471545edae4df8fd44d6034d872d04cd0e456b4b79a65
 ./packages/api-utils/tests/traits/utils.js 1.0 3a19b11d6834ed16b698115a375617fc249c3d48d651b809ae4128125ef09d12
 ./packages/api-utils/tests/traits/utils.js 1.0b3 3a19b11d6834ed16b698115a375617fc249c3d48d651b809ae4128125ef09d12
 ./packages/api-utils/tests/traits/utils.js 1.0b3rc1 3a19b11d6834ed16b698115a375617fc249c3d48d651b809ae4128125ef09d12
@@ -23348,6 +23624,7 @@
 ./packages/api-utils/tests/traits/utils.js 1.9b2 d67429c81fd0301c132961b3b7537a15da9a69753e028ea3a60342348621e63d
 ./packages/api-utils/tests/traits/utils.js 1.9b3 d67429c81fd0301c132961b3b7537a15da9a69753e028ea3a60342348621e63d
 ./packages/api-utils/tests/traits/utils.js 1.9-dev d67429c81fd0301c132961b3b7537a15da9a69753e028ea3a60342348621e63d
+./packages/api-utils/tests/traits/utils.js 1.9rc1 d67429c81fd0301c132961b3b7537a15da9a69753e028ea3a60342348621e63d
 ./packages/cuddlefish/lib/cuddlefish.js jep-31-examples 7d6fc5c606ab1083f1470a48352d2f414a75a940918f769041b2b37ee7700292
 ./packages/cuddlefish/lib/file.js jep-31-examples c8f7458126f9d0ea5d7994e36a3397048307fe80644eba5a54cfbadb52633d9c
 ./packages/cuddlefish/lib/memory.js jep-31-examples a21ff6650c716c066c2736c2f603e09fa98181584b0b070115aa20b81e05d924
@@ -26751,6 +27028,7 @@
 ./packages/test-harness/lib/harness.js 1.9b2 fd321b981f47e13a0752b0b5c8496b7c9c6f370bb7ad5f542a2eb788b3813322
 ./packages/test-harness/lib/harness.js 1.9b3 fd321b981f47e13a0752b0b5c8496b7c9c6f370bb7ad5f542a2eb788b3813322
 ./packages/test-harness/lib/harness.js 1.9-dev c144f6d8c7e9a2887d4150588b03dd8cf2e5f7466e5d7754b2aa0537afe12615
+./packages/test-harness/lib/harness.js 1.9rc1 fd321b981f47e13a0752b0b5c8496b7c9c6f370bb7ad5f542a2eb788b3813322
 ./packages/test-harness/lib/harness.js jep-31-examples 87ef7662ec2c12b0b66813e04f0288825df2f2a431a1cd6f7628b22d71720dc9
 ./packages/test-harness/lib/loader.js 1.10-dev 01adf12d7095d3dcf72c70e595c0d78904bce37e7bf61d9d14ebfe31c380d42c
 ./packages/test-harness/lib/loader.js 1.8.1 2b8efeb77051301e551a743c7dbabe0cfc24050a3364b19bf7f34683732f1b77
@@ -26766,6 +27044,7 @@
 ./packages/test-harness/lib/loader.js 1.9b2 01adf12d7095d3dcf72c70e595c0d78904bce37e7bf61d9d14ebfe31c380d42c
 ./packages/test-harness/lib/loader.js 1.9b3 01adf12d7095d3dcf72c70e595c0d78904bce37e7bf61d9d14ebfe31c380d42c
 ./packages/test-harness/lib/loader.js 1.9-dev 2b8efeb77051301e551a743c7dbabe0cfc24050a3364b19bf7f34683732f1b77
+./packages/test-harness/lib/loader.js 1.9rc1 01adf12d7095d3dcf72c70e595c0d78904bce37e7bf61d9d14ebfe31c380d42c
 ./packages/test-harness/lib/profiler-scripts/profiler.js jep-31-examples 73a0b18dd02fb800f822b1e56300890a7362c25df45a8dfba1f79fc45eb1aeb8
 ./packages/test-harness/lib/run-tests.js 0.1 91139686f73ded9a8ae538e64248edc436e549ef6f2609948198e360b9f978c4
 ./packages/test-harness/lib/run-tests.js 0.1rc1 91139686f73ded9a8ae538e64248edc436e549ef6f2609948198e360b9f978c4
@@ -26887,6 +27166,7 @@
 ./packages/test-harness/lib/run-tests.js 1.9b2 ed27b729a7b6b15901cd07f7b5b64e646d013c6c2c27297b8e033ee46753e13c
 ./packages/test-harness/lib/run-tests.js 1.9b3 ed27b729a7b6b15901cd07f7b5b64e646d013c6c2c27297b8e033ee46753e13c
 ./packages/test-harness/lib/run-tests.js 1.9-dev bde682e0a496f47aa8e06040335ee3fa9a80d607a79753e42364dc6a90281bf8
+./packages/test-harness/lib/run-tests.js 1.9rc1 ed27b729a7b6b15901cd07f7b5b64e646d013c6c2c27297b8e033ee46753e13c
 ./packages/test-harness/lib/run-tests.js jep-31-examples b09a6646ec03e4342ffed6592569f95fc1b565230f7ad71e1c78e9cfcaef7354
 ./packages/test-harness/lib/tmp-file.js 1.10-dev 349c81313f429261858acd416fb7f2b77540a12e70ed2b6d2fb2de4f79a9ee69
 ./packages/test-harness/lib/tmp-file.js 1.8.1 349c81313f429261858acd416fb7f2b77540a12e70ed2b6d2fb2de4f79a9ee69
@@ -26902,6 +27182,7 @@
 ./packages/test-harness/lib/tmp-file.js 1.9b2 349c81313f429261858acd416fb7f2b77540a12e70ed2b6d2fb2de4f79a9ee69
 ./packages/test-harness/lib/tmp-file.js 1.9b3 349c81313f429261858acd416fb7f2b77540a12e70ed2b6d2fb2de4f79a9ee69
 ./packages/test-harness/lib/tmp-file.js 1.9-dev 349c81313f429261858acd416fb7f2b77540a12e70ed2b6d2fb2de4f79a9ee69
+./packages/test-harness/lib/tmp-file.js 1.9rc1 349c81313f429261858acd416fb7f2b77540a12e70ed2b6d2fb2de4f79a9ee69
 ./packages/test-harness/tests/test-packaging.js 0.1 8972e292ced7a7e4122c5d39a9d91afcb4081b533ca0477a0fd12afadeeb0ea8
 ./packages/test-harness/tests/test-packaging.js 0.1rc1 8972e292ced7a7e4122c5d39a9d91afcb4081b533ca0477a0fd12afadeeb0ea8
 ./packages/test-harness/tests/test-packaging.js 0.1rc2 8972e292ced7a7e4122c5d39a9d91afcb4081b533ca0477a0fd12afadeeb0ea8
@@ -27022,6 +27303,7 @@
 ./packages/test-harness/tests/test-packaging.js 1.9b2 70656b3994b5d783c5992d5071a0c7fc2c73ba7172af33a1fbdd4d53765df73a
 ./packages/test-harness/tests/test-packaging.js 1.9b3 70656b3994b5d783c5992d5071a0c7fc2c73ba7172af33a1fbdd4d53765df73a
 ./packages/test-harness/tests/test-packaging.js 1.9-dev 9ef84370d83a4997b0597b94644cf3ffc8561b546f6f6292576651e9bf7a8ae0
+./packages/test-harness/tests/test-packaging.js 1.9rc1 70656b3994b5d783c5992d5071a0c7fc2c73ba7172af33a1fbdd4d53765df73a
 ./packages/test-harness/tests/test-packaging.js jep-31-examples 20fac9a0d6b9020f208fbc9e1161be9620961ec9fa62152a5a1ecc89b1dc8a1b
 ./packages/test-harness/tests/test-self.js 0.3 69c49e2774d0a10992be781d2867d62ddcc4eb4fa8d5a1007c4196f14613e392
 ./packages/test-harness/tests/test-self.js 0.3rc1 69c49e2774d0a10992be781d2867d62ddcc4eb4fa8d5a1007c4196f14613e392
@@ -27079,6 +27361,7 @@
 ./packages/test-harness/tests/test-tmp-file.js 1.9b2 ed6e3625d5a230fa09ab74153063ad47715cc12e80e30626713bb4983346a8ec
 ./packages/test-harness/tests/test-tmp-file.js 1.9b3 ed6e3625d5a230fa09ab74153063ad47715cc12e80e30626713bb4983346a8ec
 ./packages/test-harness/tests/test-tmp-file.js 1.9-dev ed6e3625d5a230fa09ab74153063ad47715cc12e80e30626713bb4983346a8ec
+./packages/test-harness/tests/test-tmp-file.js 1.9rc1 ed6e3625d5a230fa09ab74153063ad47715cc12e80e30626713bb4983346a8ec
 ./python-lib/cuddlefish/app-extension/bootstrap.js 0.4 832e4af8d402e02d5f95db90c532aeba515595fde95db44beeb21b98762f5bcb
 ./python-lib/cuddlefish/app-extension/bootstrap.js 0.4rc1 832e4af8d402e02d5f95db90c532aeba515595fde95db44beeb21b98762f5bcb
 ./python-lib/cuddlefish/app-extension/bootstrap.js 0.4rc2 832e4af8d402e02d5f95db90c532aeba515595fde95db44beeb21b98762f5bcb
@@ -27189,6 +27472,7 @@
 ./python-lib/cuddlefish/app-extension/bootstrap.js 1.9b2 1a909c1b8347aa4d8a6087d90495d567936495107ac8895590545d7c45bb766f
 ./python-lib/cuddlefish/app-extension/bootstrap.js 1.9b3 1a909c1b8347aa4d8a6087d90495d567936495107ac8895590545d7c45bb766f
 ./python-lib/cuddlefish/app-extension/bootstrap.js 1.9-dev bd676fefcddffe352c34be310150542f950f4fbad110ac21a45aac8b518d68f2
+./python-lib/cuddlefish/app-extension/bootstrap.js 1.9rc1 1a909c1b8347aa4d8a6087d90495d567936495107ac8895590545d7c45bb766f
 ./python-lib/cuddlefish/app-extension/components/harness.js 0.1 7169b0c17b5182d0e11a672b8e0bdae5600bd9be973dbd8371539d1a89d8ec38
 ./python-lib/cuddlefish/app-extension/components/harness.js 0.1rc1 fab49606e05f0fccaf471b896ff7983cfbe21651ca4954cf2c50ef2110749b71
 ./python-lib/cuddlefish/app-extension/components/harness.js 0.1rc2 7169b0c17b5182d0e11a672b8e0bdae5600bd9be973dbd8371539d1a89d8ec38
@@ -27352,6 +27636,7 @@
 ./python-lib/cuddlefish/mobile-utils/bootstrap.js 1.9b2 38259320c91a7a63c56bd36a79ae3427115f69c0e16844ea77701ddeef1e13ee
 ./python-lib/cuddlefish/mobile-utils/bootstrap.js 1.9b3 38259320c91a7a63c56bd36a79ae3427115f69c0e16844ea77701ddeef1e13ee
 ./python-lib/cuddlefish/mobile-utils/bootstrap.js 1.9-dev 38259320c91a7a63c56bd36a79ae3427115f69c0e16844ea77701ddeef1e13ee
+./python-lib/cuddlefish/mobile-utils/bootstrap.js 1.9rc1 38259320c91a7a63c56bd36a79ae3427115f69c0e16844ea77701ddeef1e13ee
 ./python-lib/cuddlefish/tests/addons/simplest-test/main.js 1.10-dev 8a6fd5806f308d8f7ddaecce36cf5da34747b2af8b7c8472e8fe1f6851c500b4
 ./python-lib/cuddlefish/tests/addons/simplest-test/main.js 1.4.1 d0b3c01e33dfb28103887760aa06de1c24fb1ee55460ed9fcfc42ebdc1cac0dc
 ./python-lib/cuddlefish/tests/addons/simplest-test/main.js 1.4.2 d0b3c01e33dfb28103887760aa06de1c24fb1ee55460ed9fcfc42ebdc1cac0dc
@@ -27398,6 +27683,7 @@
 ./python-lib/cuddlefish/tests/addons/simplest-test/main.js 1.9b2 8a6fd5806f308d8f7ddaecce36cf5da34747b2af8b7c8472e8fe1f6851c500b4
 ./python-lib/cuddlefish/tests/addons/simplest-test/main.js 1.9b3 8a6fd5806f308d8f7ddaecce36cf5da34747b2af8b7c8472e8fe1f6851c500b4
 ./python-lib/cuddlefish/tests/addons/simplest-test/main.js 1.9-dev 8a6fd5806f308d8f7ddaecce36cf5da34747b2af8b7c8472e8fe1f6851c500b4
+./python-lib/cuddlefish/tests/addons/simplest-test/main.js 1.9rc1 8a6fd5806f308d8f7ddaecce36cf5da34747b2af8b7c8472e8fe1f6851c500b4
 ./python-lib/cuddlefish/tests/addons/simplest-test/tests/test-minimal.js 1.10-dev e7f3901a6c51468b9edb0ef022e1d7fe49ca49e410649a41b1178632669ac56b
 ./python-lib/cuddlefish/tests/addons/simplest-test/tests/test-minimal.js 1.4.1 2a4b91455a83ab7aa297231bf4da1c55fea5bc4c898a4469b0583826d9580699
 ./python-lib/cuddlefish/tests/addons/simplest-test/tests/test-minimal.js 1.4.2 2a4b91455a83ab7aa297231bf4da1c55fea5bc4c898a4469b0583826d9580699
@@ -27444,6 +27730,7 @@
 ./python-lib/cuddlefish/tests/addons/simplest-test/tests/test-minimal.js 1.9b2 e7f3901a6c51468b9edb0ef022e1d7fe49ca49e410649a41b1178632669ac56b
 ./python-lib/cuddlefish/tests/addons/simplest-test/tests/test-minimal.js 1.9b3 e7f3901a6c51468b9edb0ef022e1d7fe49ca49e410649a41b1178632669ac56b
 ./python-lib/cuddlefish/tests/addons/simplest-test/tests/test-minimal.js 1.9-dev e7f3901a6c51468b9edb0ef022e1d7fe49ca49e410649a41b1178632669ac56b
+./python-lib/cuddlefish/tests/addons/simplest-test/tests/test-minimal.js 1.9rc1 e7f3901a6c51468b9edb0ef022e1d7fe49ca49e410649a41b1178632669ac56b
 ./python-lib/cuddlefish/tests/bug-588119-files/packages/explicit-icon/lib/main.js 1.0b1 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 ./python-lib/cuddlefish/tests/bug-588119-files/packages/explicit-icon/lib/main.js 1.0b1rc1 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 ./python-lib/cuddlefish/tests/bug-588119-files/packages/explicit-icon/lib/main.js 1.0b1rc2 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
@@ -27535,6 +27822,7 @@
 ./python-lib/cuddlefish/tests/bug-588119-files/packages/explicit-icon/lib/main.js 1.9b2 fbb692bbd64e4c5c7905421273af7318775a626e736435ba4b8ea725bc20ce87
 ./python-lib/cuddlefish/tests/bug-588119-files/packages/explicit-icon/lib/main.js 1.9b3 fbb692bbd64e4c5c7905421273af7318775a626e736435ba4b8ea725bc20ce87
 ./python-lib/cuddlefish/tests/bug-588119-files/packages/explicit-icon/lib/main.js 1.9-dev fbb692bbd64e4c5c7905421273af7318775a626e736435ba4b8ea725bc20ce87
+./python-lib/cuddlefish/tests/bug-588119-files/packages/explicit-icon/lib/main.js 1.9rc1 fbb692bbd64e4c5c7905421273af7318775a626e736435ba4b8ea725bc20ce87
 ./python-lib/cuddlefish/tests/bug-588119-files/packages/implicit-icon/lib/main.js 1.0b1 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 ./python-lib/cuddlefish/tests/bug-588119-files/packages/implicit-icon/lib/main.js 1.0b1rc1 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 ./python-lib/cuddlefish/tests/bug-588119-files/packages/implicit-icon/lib/main.js 1.0b1rc2 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
@@ -27626,6 +27914,7 @@
 ./python-lib/cuddlefish/tests/bug-588119-files/packages/implicit-icon/lib/main.js 1.9b2 fbb692bbd64e4c5c7905421273af7318775a626e736435ba4b8ea725bc20ce87
 ./python-lib/cuddlefish/tests/bug-588119-files/packages/implicit-icon/lib/main.js 1.9b3 fbb692bbd64e4c5c7905421273af7318775a626e736435ba4b8ea725bc20ce87
 ./python-lib/cuddlefish/tests/bug-588119-files/packages/implicit-icon/lib/main.js 1.9-dev fbb692bbd64e4c5c7905421273af7318775a626e736435ba4b8ea725bc20ce87
+./python-lib/cuddlefish/tests/bug-588119-files/packages/implicit-icon/lib/main.js 1.9rc1 fbb692bbd64e4c5c7905421273af7318775a626e736435ba4b8ea725bc20ce87
 ./python-lib/cuddlefish/tests/bug-588119-files/packages/no-icon/lib/main.js 1.0b1 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 ./python-lib/cuddlefish/tests/bug-588119-files/packages/no-icon/lib/main.js 1.0b1rc1 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 ./python-lib/cuddlefish/tests/bug-588119-files/packages/no-icon/lib/main.js 1.0b1rc2 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
@@ -27717,6 +28006,7 @@
 ./python-lib/cuddlefish/tests/bug-588119-files/packages/no-icon/lib/main.js 1.9b2 fbb692bbd64e4c5c7905421273af7318775a626e736435ba4b8ea725bc20ce87
 ./python-lib/cuddlefish/tests/bug-588119-files/packages/no-icon/lib/main.js 1.9b3 fbb692bbd64e4c5c7905421273af7318775a626e736435ba4b8ea725bc20ce87
 ./python-lib/cuddlefish/tests/bug-588119-files/packages/no-icon/lib/main.js 1.9-dev fbb692bbd64e4c5c7905421273af7318775a626e736435ba4b8ea725bc20ce87
+./python-lib/cuddlefish/tests/bug-588119-files/packages/no-icon/lib/main.js 1.9rc1 fbb692bbd64e4c5c7905421273af7318775a626e736435ba4b8ea725bc20ce87
 ./python-lib/cuddlefish/tests/bug-588661-files/packages/bar/lib/bar-loader.js 0.8 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 ./python-lib/cuddlefish/tests/bug-588661-files/packages/bar/lib/bar-loader.js 0.8rc1 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 ./python-lib/cuddlefish/tests/bug-588661-files/packages/bar/lib/bar-loader.js 0.9 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
@@ -27813,6 +28103,7 @@
 ./python-lib/cuddlefish/tests/bug-588661-files/packages/bar/lib/bar-loader.js 1.9b2 fbb692bbd64e4c5c7905421273af7318775a626e736435ba4b8ea725bc20ce87
 ./python-lib/cuddlefish/tests/bug-588661-files/packages/bar/lib/bar-loader.js 1.9b3 fbb692bbd64e4c5c7905421273af7318775a626e736435ba4b8ea725bc20ce87
 ./python-lib/cuddlefish/tests/bug-588661-files/packages/bar/lib/bar-loader.js 1.9-dev fbb692bbd64e4c5c7905421273af7318775a626e736435ba4b8ea725bc20ce87
+./python-lib/cuddlefish/tests/bug-588661-files/packages/bar/lib/bar-loader.js 1.9rc1 fbb692bbd64e4c5c7905421273af7318775a626e736435ba4b8ea725bc20ce87
 ./python-lib/cuddlefish/tests/bug-588661-files/packages/foo/lib/foo-loader.js 0.8 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 ./python-lib/cuddlefish/tests/bug-588661-files/packages/foo/lib/foo-loader.js 0.8rc1 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 ./python-lib/cuddlefish/tests/bug-588661-files/packages/foo/lib/foo-loader.js 0.9 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
@@ -27909,6 +28200,7 @@
 ./python-lib/cuddlefish/tests/bug-588661-files/packages/foo/lib/foo-loader.js 1.9b2 fbb692bbd64e4c5c7905421273af7318775a626e736435ba4b8ea725bc20ce87
 ./python-lib/cuddlefish/tests/bug-588661-files/packages/foo/lib/foo-loader.js 1.9b3 fbb692bbd64e4c5c7905421273af7318775a626e736435ba4b8ea725bc20ce87
 ./python-lib/cuddlefish/tests/bug-588661-files/packages/foo/lib/foo-loader.js 1.9-dev fbb692bbd64e4c5c7905421273af7318775a626e736435ba4b8ea725bc20ce87
+./python-lib/cuddlefish/tests/bug-588661-files/packages/foo/lib/foo-loader.js 1.9rc1 fbb692bbd64e4c5c7905421273af7318775a626e736435ba4b8ea725bc20ce87
 ./python-lib/cuddlefish/tests/bug-611495-files/jspath-one/lib/main.js 1.0 a6f35c3779248dd99d22749d8f7c203a2fe93a8896d40b19e6a331313badfbc8
 ./python-lib/cuddlefish/tests/bug-611495-files/jspath-one/lib/main.js 1.0b5 a6f35c3779248dd99d22749d8f7c203a2fe93a8896d40b19e6a331313badfbc8
 ./python-lib/cuddlefish/tests/bug-611495-files/jspath-one/lib/main.js 1.0b5rc1 a6f35c3779248dd99d22749d8f7c203a2fe93a8896d40b19e6a331313badfbc8
@@ -27984,6 +28276,7 @@
 ./python-lib/cuddlefish/tests/bug-611495-files/jspath-one/lib/main.js 1.9b2 ceb04288fd0191fb07d161bfb8973ccea6ed1c005b8ad361e6d9ae7289333d83
 ./python-lib/cuddlefish/tests/bug-611495-files/jspath-one/lib/main.js 1.9b3 ceb04288fd0191fb07d161bfb8973ccea6ed1c005b8ad361e6d9ae7289333d83
 ./python-lib/cuddlefish/tests/bug-611495-files/jspath-one/lib/main.js 1.9-dev ceb04288fd0191fb07d161bfb8973ccea6ed1c005b8ad361e6d9ae7289333d83
+./python-lib/cuddlefish/tests/bug-611495-files/jspath-one/lib/main.js 1.9rc1 ceb04288fd0191fb07d161bfb8973ccea6ed1c005b8ad361e6d9ae7289333d83
 ./python-lib/cuddlefish/tests/bug-614712-files/packages/commonjs-naming/lib/foo-loader.js 1.0 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
 ./python-lib/cuddlefish/tests/bug-614712-files/packages/commonjs-naming/lib/foo-loader.js 1.0b5 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
 ./python-lib/cuddlefish/tests/bug-614712-files/packages/commonjs-naming/lib/foo-loader.js 1.0b5rc1 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
@@ -28059,6 +28352,7 @@
 ./python-lib/cuddlefish/tests/bug-614712-files/packages/commonjs-naming/lib/foo-loader.js 1.9b2 a5e60e519a8a0611410c939a105f8ae6c59796e04d88825cdb03035206ce2417
 ./python-lib/cuddlefish/tests/bug-614712-files/packages/commonjs-naming/lib/foo-loader.js 1.9b3 a5e60e519a8a0611410c939a105f8ae6c59796e04d88825cdb03035206ce2417
 ./python-lib/cuddlefish/tests/bug-614712-files/packages/commonjs-naming/lib/foo-loader.js 1.9-dev a5e60e519a8a0611410c939a105f8ae6c59796e04d88825cdb03035206ce2417
+./python-lib/cuddlefish/tests/bug-614712-files/packages/commonjs-naming/lib/foo-loader.js 1.9rc1 a5e60e519a8a0611410c939a105f8ae6c59796e04d88825cdb03035206ce2417
 ./python-lib/cuddlefish/tests/bug-614712-files/packages/commonjs-naming/test/test-foo.js 1.0b5 d01209ddd865cdc48d4dc8ad741ee4fdc7d4270f95f50b5547402d9043db3394
 ./python-lib/cuddlefish/tests/bug-614712-files/packages/commonjs-naming/test/test-foo.js 1.0b5rc1 d01209ddd865cdc48d4dc8ad741ee4fdc7d4270f95f50b5547402d9043db3394
 ./python-lib/cuddlefish/tests/bug-614712-files/packages/commonjs-naming/test/test-foo.js 1.0b5rc2 d01209ddd865cdc48d4dc8ad741ee4fdc7d4270f95f50b5547402d9043db3394
@@ -28134,6 +28428,7 @@
 ./python-lib/cuddlefish/tests/bug-614712-files/packages/commonjs-naming/test/test-foo.js 1.9b2 4295891d8469f7faa35974a45c6e7a4323522c0e14d6857f9edf3ad5104ddd0c
 ./python-lib/cuddlefish/tests/bug-614712-files/packages/commonjs-naming/test/test-foo.js 1.9b3 4295891d8469f7faa35974a45c6e7a4323522c0e14d6857f9edf3ad5104ddd0c
 ./python-lib/cuddlefish/tests/bug-614712-files/packages/commonjs-naming/test/test-foo.js 1.9-dev 4295891d8469f7faa35974a45c6e7a4323522c0e14d6857f9edf3ad5104ddd0c
+./python-lib/cuddlefish/tests/bug-614712-files/packages/commonjs-naming/test/test-foo.js 1.9rc1 4295891d8469f7faa35974a45c6e7a4323522c0e14d6857f9edf3ad5104ddd0c
 ./python-lib/cuddlefish/tests/bug-614712-files/packages/original-naming/lib/foo-loader.js 1.0 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
 ./python-lib/cuddlefish/tests/bug-614712-files/packages/original-naming/lib/foo-loader.js 1.0b5 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
 ./python-lib/cuddlefish/tests/bug-614712-files/packages/original-naming/lib/foo-loader.js 1.0b5rc1 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
@@ -28209,6 +28504,7 @@
 ./python-lib/cuddlefish/tests/bug-614712-files/packages/original-naming/lib/foo-loader.js 1.9b2 a5e60e519a8a0611410c939a105f8ae6c59796e04d88825cdb03035206ce2417
 ./python-lib/cuddlefish/tests/bug-614712-files/packages/original-naming/lib/foo-loader.js 1.9b3 a5e60e519a8a0611410c939a105f8ae6c59796e04d88825cdb03035206ce2417
 ./python-lib/cuddlefish/tests/bug-614712-files/packages/original-naming/lib/foo-loader.js 1.9-dev a5e60e519a8a0611410c939a105f8ae6c59796e04d88825cdb03035206ce2417
+./python-lib/cuddlefish/tests/bug-614712-files/packages/original-naming/lib/foo-loader.js 1.9rc1 a5e60e519a8a0611410c939a105f8ae6c59796e04d88825cdb03035206ce2417
 ./python-lib/cuddlefish/tests/bug-614712-files/packages/original-naming/tests/test-foo.js 1.0b5 d01209ddd865cdc48d4dc8ad741ee4fdc7d4270f95f50b5547402d9043db3394
 ./python-lib/cuddlefish/tests/bug-614712-files/packages/original-naming/tests/test-foo.js 1.0b5rc1 d01209ddd865cdc48d4dc8ad741ee4fdc7d4270f95f50b5547402d9043db3394
 ./python-lib/cuddlefish/tests/bug-614712-files/packages/original-naming/tests/test-foo.js 1.0b5rc2 d01209ddd865cdc48d4dc8ad741ee4fdc7d4270f95f50b5547402d9043db3394
@@ -28284,6 +28580,7 @@
 ./python-lib/cuddlefish/tests/bug-614712-files/packages/original-naming/tests/test-foo.js 1.9b2 4295891d8469f7faa35974a45c6e7a4323522c0e14d6857f9edf3ad5104ddd0c
 ./python-lib/cuddlefish/tests/bug-614712-files/packages/original-naming/tests/test-foo.js 1.9b3 4295891d8469f7faa35974a45c6e7a4323522c0e14d6857f9edf3ad5104ddd0c
 ./python-lib/cuddlefish/tests/bug-614712-files/packages/original-naming/tests/test-foo.js 1.9-dev 4295891d8469f7faa35974a45c6e7a4323522c0e14d6857f9edf3ad5104ddd0c
+./python-lib/cuddlefish/tests/bug-614712-files/packages/original-naming/tests/test-foo.js 1.9rc1 4295891d8469f7faa35974a45c6e7a4323522c0e14d6857f9edf3ad5104ddd0c
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/default-lib/lib/foo.js 1.0 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/default-lib/lib/foo.js 1.0rc1 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/default-lib/lib/foo.js 1.0rc2 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
@@ -28356,6 +28653,7 @@
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/default-lib/lib/foo.js 1.9b2 a5e60e519a8a0611410c939a105f8ae6c59796e04d88825cdb03035206ce2417
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/default-lib/lib/foo.js 1.9b3 a5e60e519a8a0611410c939a105f8ae6c59796e04d88825cdb03035206ce2417
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/default-lib/lib/foo.js 1.9-dev a5e60e519a8a0611410c939a105f8ae6c59796e04d88825cdb03035206ce2417
+./python-lib/cuddlefish/tests/bug-652227-files/packages/default-lib/lib/foo.js 1.9rc1 a5e60e519a8a0611410c939a105f8ae6c59796e04d88825cdb03035206ce2417
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/default-lib/lib/loader.js 1.0 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/default-lib/lib/loader.js 1.0rc1 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/default-lib/lib/loader.js 1.0rc2 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
@@ -28428,6 +28726,7 @@
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/default-lib/lib/loader.js 1.9b2 a5e60e519a8a0611410c939a105f8ae6c59796e04d88825cdb03035206ce2417
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/default-lib/lib/loader.js 1.9b3 a5e60e519a8a0611410c939a105f8ae6c59796e04d88825cdb03035206ce2417
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/default-lib/lib/loader.js 1.9-dev a5e60e519a8a0611410c939a105f8ae6c59796e04d88825cdb03035206ce2417
+./python-lib/cuddlefish/tests/bug-652227-files/packages/default-lib/lib/loader.js 1.9rc1 a5e60e519a8a0611410c939a105f8ae6c59796e04d88825cdb03035206ce2417
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/default-lib/test/test-foo.js 1.0 d01209ddd865cdc48d4dc8ad741ee4fdc7d4270f95f50b5547402d9043db3394
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/default-lib/test/test-foo.js 1.0rc1 d01209ddd865cdc48d4dc8ad741ee4fdc7d4270f95f50b5547402d9043db3394
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/default-lib/test/test-foo.js 1.0rc2 d01209ddd865cdc48d4dc8ad741ee4fdc7d4270f95f50b5547402d9043db3394
@@ -28500,6 +28799,7 @@
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/default-lib/test/test-foo.js 1.9b2 4295891d8469f7faa35974a45c6e7a4323522c0e14d6857f9edf3ad5104ddd0c
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/default-lib/test/test-foo.js 1.9b3 4295891d8469f7faa35974a45c6e7a4323522c0e14d6857f9edf3ad5104ddd0c
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/default-lib/test/test-foo.js 1.9-dev 4295891d8469f7faa35974a45c6e7a4323522c0e14d6857f9edf3ad5104ddd0c
+./python-lib/cuddlefish/tests/bug-652227-files/packages/default-lib/test/test-foo.js 1.9rc1 4295891d8469f7faa35974a45c6e7a4323522c0e14d6857f9edf3ad5104ddd0c
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/default-root/foo.js 1.0 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/default-root/foo.js 1.0rc1 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/default-root/foo.js 1.0rc2 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
@@ -28572,6 +28872,7 @@
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/default-root/foo.js 1.9b2 a5e60e519a8a0611410c939a105f8ae6c59796e04d88825cdb03035206ce2417
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/default-root/foo.js 1.9b3 a5e60e519a8a0611410c939a105f8ae6c59796e04d88825cdb03035206ce2417
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/default-root/foo.js 1.9-dev a5e60e519a8a0611410c939a105f8ae6c59796e04d88825cdb03035206ce2417
+./python-lib/cuddlefish/tests/bug-652227-files/packages/default-root/foo.js 1.9rc1 a5e60e519a8a0611410c939a105f8ae6c59796e04d88825cdb03035206ce2417
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/default-root/loader.js 1.0 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/default-root/loader.js 1.0rc1 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/default-root/loader.js 1.0rc2 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
@@ -28644,6 +28945,7 @@
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/default-root/loader.js 1.9b2 a5e60e519a8a0611410c939a105f8ae6c59796e04d88825cdb03035206ce2417
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/default-root/loader.js 1.9b3 a5e60e519a8a0611410c939a105f8ae6c59796e04d88825cdb03035206ce2417
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/default-root/loader.js 1.9-dev a5e60e519a8a0611410c939a105f8ae6c59796e04d88825cdb03035206ce2417
+./python-lib/cuddlefish/tests/bug-652227-files/packages/default-root/loader.js 1.9rc1 a5e60e519a8a0611410c939a105f8ae6c59796e04d88825cdb03035206ce2417
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/default-root/test/test-foo.js 1.0 d01209ddd865cdc48d4dc8ad741ee4fdc7d4270f95f50b5547402d9043db3394
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/default-root/test/test-foo.js 1.0rc1 d01209ddd865cdc48d4dc8ad741ee4fdc7d4270f95f50b5547402d9043db3394
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/default-root/test/test-foo.js 1.0rc2 d01209ddd865cdc48d4dc8ad741ee4fdc7d4270f95f50b5547402d9043db3394
@@ -28716,6 +29018,7 @@
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/default-root/test/test-foo.js 1.9b2 4295891d8469f7faa35974a45c6e7a4323522c0e14d6857f9edf3ad5104ddd0c
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/default-root/test/test-foo.js 1.9b3 4295891d8469f7faa35974a45c6e7a4323522c0e14d6857f9edf3ad5104ddd0c
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/default-root/test/test-foo.js 1.9-dev 4295891d8469f7faa35974a45c6e7a4323522c0e14d6857f9edf3ad5104ddd0c
+./python-lib/cuddlefish/tests/bug-652227-files/packages/default-root/test/test-foo.js 1.9rc1 4295891d8469f7faa35974a45c6e7a4323522c0e14d6857f9edf3ad5104ddd0c
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/explicit-dir-lib/alt-lib/foo.js 1.0 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/explicit-dir-lib/alt-lib/foo.js 1.0rc1 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/explicit-dir-lib/alt-lib/foo.js 1.0rc2 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
@@ -28788,6 +29091,7 @@
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/explicit-dir-lib/alt-lib/foo.js 1.9b2 a5e60e519a8a0611410c939a105f8ae6c59796e04d88825cdb03035206ce2417
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/explicit-dir-lib/alt-lib/foo.js 1.9b3 a5e60e519a8a0611410c939a105f8ae6c59796e04d88825cdb03035206ce2417
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/explicit-dir-lib/alt-lib/foo.js 1.9-dev a5e60e519a8a0611410c939a105f8ae6c59796e04d88825cdb03035206ce2417
+./python-lib/cuddlefish/tests/bug-652227-files/packages/explicit-dir-lib/alt-lib/foo.js 1.9rc1 a5e60e519a8a0611410c939a105f8ae6c59796e04d88825cdb03035206ce2417
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/explicit-dir-lib/alt-lib/loader.js 1.0 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/explicit-dir-lib/alt-lib/loader.js 1.0rc1 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/explicit-dir-lib/alt-lib/loader.js 1.0rc2 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
@@ -28860,6 +29164,7 @@
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/explicit-dir-lib/alt-lib/loader.js 1.9b2 a5e60e519a8a0611410c939a105f8ae6c59796e04d88825cdb03035206ce2417
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/explicit-dir-lib/alt-lib/loader.js 1.9b3 a5e60e519a8a0611410c939a105f8ae6c59796e04d88825cdb03035206ce2417
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/explicit-dir-lib/alt-lib/loader.js 1.9-dev a5e60e519a8a0611410c939a105f8ae6c59796e04d88825cdb03035206ce2417
+./python-lib/cuddlefish/tests/bug-652227-files/packages/explicit-dir-lib/alt-lib/loader.js 1.9rc1 a5e60e519a8a0611410c939a105f8ae6c59796e04d88825cdb03035206ce2417
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/explicit-dir-lib/test/test-foo.js 1.0 d01209ddd865cdc48d4dc8ad741ee4fdc7d4270f95f50b5547402d9043db3394
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/explicit-dir-lib/test/test-foo.js 1.0rc1 d01209ddd865cdc48d4dc8ad741ee4fdc7d4270f95f50b5547402d9043db3394
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/explicit-dir-lib/test/test-foo.js 1.0rc2 d01209ddd865cdc48d4dc8ad741ee4fdc7d4270f95f50b5547402d9043db3394
@@ -28932,6 +29237,7 @@
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/explicit-dir-lib/test/test-foo.js 1.9b2 4295891d8469f7faa35974a45c6e7a4323522c0e14d6857f9edf3ad5104ddd0c
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/explicit-dir-lib/test/test-foo.js 1.9b3 4295891d8469f7faa35974a45c6e7a4323522c0e14d6857f9edf3ad5104ddd0c
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/explicit-dir-lib/test/test-foo.js 1.9-dev 4295891d8469f7faa35974a45c6e7a4323522c0e14d6857f9edf3ad5104ddd0c
+./python-lib/cuddlefish/tests/bug-652227-files/packages/explicit-dir-lib/test/test-foo.js 1.9rc1 4295891d8469f7faa35974a45c6e7a4323522c0e14d6857f9edf3ad5104ddd0c
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/explicit-lib/alt2-lib/foo.js 1.0 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/explicit-lib/alt2-lib/foo.js 1.0rc1 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/explicit-lib/alt2-lib/foo.js 1.0rc2 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
@@ -29004,6 +29310,7 @@
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/explicit-lib/alt2-lib/foo.js 1.9b2 a5e60e519a8a0611410c939a105f8ae6c59796e04d88825cdb03035206ce2417
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/explicit-lib/alt2-lib/foo.js 1.9b3 a5e60e519a8a0611410c939a105f8ae6c59796e04d88825cdb03035206ce2417
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/explicit-lib/alt2-lib/foo.js 1.9-dev a5e60e519a8a0611410c939a105f8ae6c59796e04d88825cdb03035206ce2417
+./python-lib/cuddlefish/tests/bug-652227-files/packages/explicit-lib/alt2-lib/foo.js 1.9rc1 a5e60e519a8a0611410c939a105f8ae6c59796e04d88825cdb03035206ce2417
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/explicit-lib/alt2-lib/loader.js 1.0 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/explicit-lib/alt2-lib/loader.js 1.0rc1 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/explicit-lib/alt2-lib/loader.js 1.0rc2 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
@@ -29076,6 +29383,7 @@
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/explicit-lib/alt2-lib/loader.js 1.9b2 a5e60e519a8a0611410c939a105f8ae6c59796e04d88825cdb03035206ce2417
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/explicit-lib/alt2-lib/loader.js 1.9b3 a5e60e519a8a0611410c939a105f8ae6c59796e04d88825cdb03035206ce2417
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/explicit-lib/alt2-lib/loader.js 1.9-dev a5e60e519a8a0611410c939a105f8ae6c59796e04d88825cdb03035206ce2417
+./python-lib/cuddlefish/tests/bug-652227-files/packages/explicit-lib/alt2-lib/loader.js 1.9rc1 a5e60e519a8a0611410c939a105f8ae6c59796e04d88825cdb03035206ce2417
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/explicit-lib/test/test-foo.js 1.0 d01209ddd865cdc48d4dc8ad741ee4fdc7d4270f95f50b5547402d9043db3394
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/explicit-lib/test/test-foo.js 1.0rc1 d01209ddd865cdc48d4dc8ad741ee4fdc7d4270f95f50b5547402d9043db3394
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/explicit-lib/test/test-foo.js 1.0rc2 d01209ddd865cdc48d4dc8ad741ee4fdc7d4270f95f50b5547402d9043db3394
@@ -29148,6 +29456,7 @@
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/explicit-lib/test/test-foo.js 1.9b2 4295891d8469f7faa35974a45c6e7a4323522c0e14d6857f9edf3ad5104ddd0c
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/explicit-lib/test/test-foo.js 1.9b3 4295891d8469f7faa35974a45c6e7a4323522c0e14d6857f9edf3ad5104ddd0c
 ./python-lib/cuddlefish/tests/bug-652227-files/packages/explicit-lib/test/test-foo.js 1.9-dev 4295891d8469f7faa35974a45c6e7a4323522c0e14d6857f9edf3ad5104ddd0c
+./python-lib/cuddlefish/tests/bug-652227-files/packages/explicit-lib/test/test-foo.js 1.9rc1 4295891d8469f7faa35974a45c6e7a4323522c0e14d6857f9edf3ad5104ddd0c
 ./python-lib/cuddlefish/tests/bug-669274-files/packages/extra-options/lib/main.js 1.10-dev ceb04288fd0191fb07d161bfb8973ccea6ed1c005b8ad361e6d9ae7289333d83
 ./python-lib/cuddlefish/tests/bug-669274-files/packages/extra-options/lib/main.js 1.3 a6f35c3779248dd99d22749d8f7c203a2fe93a8896d40b19e6a331313badfbc8
 ./python-lib/cuddlefish/tests/bug-669274-files/packages/extra-options/lib/main.js 1.3b3 a6f35c3779248dd99d22749d8f7c203a2fe93a8896d40b19e6a331313badfbc8
@@ -29199,6 +29508,7 @@
 ./python-lib/cuddlefish/tests/bug-669274-files/packages/extra-options/lib/main.js 1.9b2 ceb04288fd0191fb07d161bfb8973ccea6ed1c005b8ad361e6d9ae7289333d83
 ./python-lib/cuddlefish/tests/bug-669274-files/packages/extra-options/lib/main.js 1.9b3 ceb04288fd0191fb07d161bfb8973ccea6ed1c005b8ad361e6d9ae7289333d83
 ./python-lib/cuddlefish/tests/bug-669274-files/packages/extra-options/lib/main.js 1.9-dev ceb04288fd0191fb07d161bfb8973ccea6ed1c005b8ad361e6d9ae7289333d83
+./python-lib/cuddlefish/tests/bug-669274-files/packages/extra-options/lib/main.js 1.9rc1 ceb04288fd0191fb07d161bfb8973ccea6ed1c005b8ad361e6d9ae7289333d83
 ./python-lib/cuddlefish/tests/e10s-adapter-files/packages/foo/lib/bar-e10s-adapter.js 1.0 a26c6811d28c031577f2c0a53d7d3aa00c77c725e2ceb090e605540c37fa56ae
 ./python-lib/cuddlefish/tests/e10s-adapter-files/packages/foo/lib/bar-e10s-adapter.js 1.0b1 a26c6811d28c031577f2c0a53d7d3aa00c77c725e2ceb090e605540c37fa56ae
 ./python-lib/cuddlefish/tests/e10s-adapter-files/packages/foo/lib/bar-e10s-adapter.js 1.0b1rc1 a26c6811d28c031577f2c0a53d7d3aa00c77c725e2ceb090e605540c37fa56ae
@@ -29290,6 +29600,7 @@
 ./python-lib/cuddlefish/tests/e10s-adapter-files/packages/foo/lib/bar-e10s-adapter.js 1.9b2 592e7977832b266f57f7d6cfdc4dc8e8a0ab01d307083574c566212f735a7128
 ./python-lib/cuddlefish/tests/e10s-adapter-files/packages/foo/lib/bar-e10s-adapter.js 1.9b3 592e7977832b266f57f7d6cfdc4dc8e8a0ab01d307083574c566212f735a7128
 ./python-lib/cuddlefish/tests/e10s-adapter-files/packages/foo/lib/bar-e10s-adapter.js 1.9-dev 592e7977832b266f57f7d6cfdc4dc8e8a0ab01d307083574c566212f735a7128
+./python-lib/cuddlefish/tests/e10s-adapter-files/packages/foo/lib/bar-e10s-adapter.js 1.9rc1 592e7977832b266f57f7d6cfdc4dc8e8a0ab01d307083574c566212f735a7128
 ./python-lib/cuddlefish/tests/e10s-adapter-files/packages/foo/lib/bar.js 1.0 7cc1e8beb989ce0cdb97b37ee2487f6c79e177934494c933ee5cd88c8a12e3ff
 ./python-lib/cuddlefish/tests/e10s-adapter-files/packages/foo/lib/bar.js 1.0b1 7cc1e8beb989ce0cdb97b37ee2487f6c79e177934494c933ee5cd88c8a12e3ff
 ./python-lib/cuddlefish/tests/e10s-adapter-files/packages/foo/lib/bar.js 1.0b1rc1 7cc1e8beb989ce0cdb97b37ee2487f6c79e177934494c933ee5cd88c8a12e3ff
@@ -29381,6 +29692,7 @@
 ./python-lib/cuddlefish/tests/e10s-adapter-files/packages/foo/lib/bar.js 1.9b2 41868e0832d762ab54dc1f9270685edc407e78e96adb97fd0799e2f50090d778
 ./python-lib/cuddlefish/tests/e10s-adapter-files/packages/foo/lib/bar.js 1.9b3 41868e0832d762ab54dc1f9270685edc407e78e96adb97fd0799e2f50090d778
 ./python-lib/cuddlefish/tests/e10s-adapter-files/packages/foo/lib/bar.js 1.9-dev 41868e0832d762ab54dc1f9270685edc407e78e96adb97fd0799e2f50090d778
+./python-lib/cuddlefish/tests/e10s-adapter-files/packages/foo/lib/bar.js 1.9rc1 41868e0832d762ab54dc1f9270685edc407e78e96adb97fd0799e2f50090d778
 ./python-lib/cuddlefish/tests/e10s-adapter-files/packages/foo/lib/foo.js 1.0 0b5dad999de23fdcfaf96a3b6cf3cb4f8f0107f612b1f7e2f43866711de8bf3e
 ./python-lib/cuddlefish/tests/e10s-adapter-files/packages/foo/lib/foo.js 1.0b1 0b5dad999de23fdcfaf96a3b6cf3cb4f8f0107f612b1f7e2f43866711de8bf3e
 ./python-lib/cuddlefish/tests/e10s-adapter-files/packages/foo/lib/foo.js 1.0b1rc1 0b5dad999de23fdcfaf96a3b6cf3cb4f8f0107f612b1f7e2f43866711de8bf3e
@@ -29472,6 +29784,7 @@
 ./python-lib/cuddlefish/tests/e10s-adapter-files/packages/foo/lib/foo.js 1.9b2 80c7b0d9a1ebbcf1c2ae084d8d82979dcb48f9aaa42b98fed70f09bd1cba62a6
 ./python-lib/cuddlefish/tests/e10s-adapter-files/packages/foo/lib/foo.js 1.9b3 80c7b0d9a1ebbcf1c2ae084d8d82979dcb48f9aaa42b98fed70f09bd1cba62a6
 ./python-lib/cuddlefish/tests/e10s-adapter-files/packages/foo/lib/foo.js 1.9-dev 80c7b0d9a1ebbcf1c2ae084d8d82979dcb48f9aaa42b98fed70f09bd1cba62a6
+./python-lib/cuddlefish/tests/e10s-adapter-files/packages/foo/lib/foo.js 1.9rc1 80c7b0d9a1ebbcf1c2ae084d8d82979dcb48f9aaa42b98fed70f09bd1cba62a6
 ./python-lib/cuddlefish/tests/linker-files/five/lib/main.js 1.0 3c0ad79c8b0841a27cc8c85492890c82c37131e21ddea70b3b30136d013edfb5
 ./python-lib/cuddlefish/tests/linker-files/five/lib/main.js 1.0rc1 3c0ad79c8b0841a27cc8c85492890c82c37131e21ddea70b3b30136d013edfb5
 ./python-lib/cuddlefish/tests/linker-files/five/lib/main.js 1.0rc2 3c0ad79c8b0841a27cc8c85492890c82c37131e21ddea70b3b30136d013edfb5
@@ -29544,6 +29857,7 @@
 ./python-lib/cuddlefish/tests/linker-files/five/lib/main.js 1.9b2 159d3f428983149ccda89743b75d36fae9bfbe5375a3b9f9a44e6da4cf247583
 ./python-lib/cuddlefish/tests/linker-files/five/lib/main.js 1.9b3 159d3f428983149ccda89743b75d36fae9bfbe5375a3b9f9a44e6da4cf247583
 ./python-lib/cuddlefish/tests/linker-files/five/lib/main.js 1.9-dev 159d3f428983149ccda89743b75d36fae9bfbe5375a3b9f9a44e6da4cf247583
+./python-lib/cuddlefish/tests/linker-files/five/lib/main.js 1.9rc1 159d3f428983149ccda89743b75d36fae9bfbe5375a3b9f9a44e6da4cf247583
 ./python-lib/cuddlefish/tests/linker-files/four-deps/four-a/lib/misc.js 1.0 a3d0b75a5e98edfafb783fce616e4a8f2bd39933eed7e52ae3a79f5e15f17823
 ./python-lib/cuddlefish/tests/linker-files/four-deps/four-a/lib/misc.js 1.0rc1 a3d0b75a5e98edfafb783fce616e4a8f2bd39933eed7e52ae3a79f5e15f17823
 ./python-lib/cuddlefish/tests/linker-files/four-deps/four-a/lib/misc.js 1.0rc2 a3d0b75a5e98edfafb783fce616e4a8f2bd39933eed7e52ae3a79f5e15f17823
@@ -29616,6 +29930,7 @@
 ./python-lib/cuddlefish/tests/linker-files/four-deps/four-a/lib/misc.js 1.9b2 e08f8b97ba1d2140799ee42f15119670400fa255b4deadfaf3dcde02244567f5
 ./python-lib/cuddlefish/tests/linker-files/four-deps/four-a/lib/misc.js 1.9b3 e08f8b97ba1d2140799ee42f15119670400fa255b4deadfaf3dcde02244567f5
 ./python-lib/cuddlefish/tests/linker-files/four-deps/four-a/lib/misc.js 1.9-dev e08f8b97ba1d2140799ee42f15119670400fa255b4deadfaf3dcde02244567f5
+./python-lib/cuddlefish/tests/linker-files/four-deps/four-a/lib/misc.js 1.9rc1 e08f8b97ba1d2140799ee42f15119670400fa255b4deadfaf3dcde02244567f5
 ./python-lib/cuddlefish/tests/linker-files/four-deps/four-a/topfiles/main.js 1.0 a3d0b75a5e98edfafb783fce616e4a8f2bd39933eed7e52ae3a79f5e15f17823
 ./python-lib/cuddlefish/tests/linker-files/four-deps/four-a/topfiles/main.js 1.0rc1 a3d0b75a5e98edfafb783fce616e4a8f2bd39933eed7e52ae3a79f5e15f17823
 ./python-lib/cuddlefish/tests/linker-files/four-deps/four-a/topfiles/main.js 1.0rc2 a3d0b75a5e98edfafb783fce616e4a8f2bd39933eed7e52ae3a79f5e15f17823
@@ -29688,6 +30003,7 @@
 ./python-lib/cuddlefish/tests/linker-files/four-deps/four-a/topfiles/main.js 1.9b2 e08f8b97ba1d2140799ee42f15119670400fa255b4deadfaf3dcde02244567f5
 ./python-lib/cuddlefish/tests/linker-files/four-deps/four-a/topfiles/main.js 1.9b3 e08f8b97ba1d2140799ee42f15119670400fa255b4deadfaf3dcde02244567f5
 ./python-lib/cuddlefish/tests/linker-files/four-deps/four-a/topfiles/main.js 1.9-dev e08f8b97ba1d2140799ee42f15119670400fa255b4deadfaf3dcde02244567f5
+./python-lib/cuddlefish/tests/linker-files/four-deps/four-a/topfiles/main.js 1.9rc1 e08f8b97ba1d2140799ee42f15119670400fa255b4deadfaf3dcde02244567f5
 ./python-lib/cuddlefish/tests/linker-files/four/lib/main.js 1.0 060ee8f023ad54f900b3a18d2bc0ffdcb9277ad892e0676aa22a97b931213c63
 ./python-lib/cuddlefish/tests/linker-files/four/lib/main.js 1.0rc1 060ee8f023ad54f900b3a18d2bc0ffdcb9277ad892e0676aa22a97b931213c63
 ./python-lib/cuddlefish/tests/linker-files/four/lib/main.js 1.0rc2 060ee8f023ad54f900b3a18d2bc0ffdcb9277ad892e0676aa22a97b931213c63
@@ -29760,6 +30076,7 @@
 ./python-lib/cuddlefish/tests/linker-files/four/lib/main.js 1.9b2 3723cd1aa6d6ba597b30b1b53e423129c8d49988692529bdf1e162ea2307bd89
 ./python-lib/cuddlefish/tests/linker-files/four/lib/main.js 1.9b3 3723cd1aa6d6ba597b30b1b53e423129c8d49988692529bdf1e162ea2307bd89
 ./python-lib/cuddlefish/tests/linker-files/four/lib/main.js 1.9-dev 3723cd1aa6d6ba597b30b1b53e423129c8d49988692529bdf1e162ea2307bd89
+./python-lib/cuddlefish/tests/linker-files/four/lib/main.js 1.9rc1 3723cd1aa6d6ba597b30b1b53e423129c8d49988692529bdf1e162ea2307bd89
 ./python-lib/cuddlefish/tests/linker-files/one/lib/main.js 1.0 261d68f35cdb89026416427a47bb18c1dc7aaa08b8c3151b6e70946e69e15cf5
 ./python-lib/cuddlefish/tests/linker-files/one/lib/main.js 1.0b5 261d68f35cdb89026416427a47bb18c1dc7aaa08b8c3151b6e70946e69e15cf5
 ./python-lib/cuddlefish/tests/linker-files/one/lib/main.js 1.0b5rc2 261d68f35cdb89026416427a47bb18c1dc7aaa08b8c3151b6e70946e69e15cf5
@@ -29834,6 +30151,7 @@
 ./python-lib/cuddlefish/tests/linker-files/one/lib/main.js 1.9b2 0ee442ab7f30b3abe7571c066040a8dc0edbac3544a68139507b232ee5fc6777
 ./python-lib/cuddlefish/tests/linker-files/one/lib/main.js 1.9b3 0ee442ab7f30b3abe7571c066040a8dc0edbac3544a68139507b232ee5fc6777
 ./python-lib/cuddlefish/tests/linker-files/one/lib/main.js 1.9-dev 0ee442ab7f30b3abe7571c066040a8dc0edbac3544a68139507b232ee5fc6777
+./python-lib/cuddlefish/tests/linker-files/one/lib/main.js 1.9rc1 0ee442ab7f30b3abe7571c066040a8dc0edbac3544a68139507b232ee5fc6777
 ./python-lib/cuddlefish/tests/linker-files/one/lib/subdir/three.js 1.0 11aaec5fd8a4d5426d52957e1a1472a0971b42a1100fa4c5a57a8aacec181ed6
 ./python-lib/cuddlefish/tests/linker-files/one/lib/subdir/three.js 1.0b5 11aaec5fd8a4d5426d52957e1a1472a0971b42a1100fa4c5a57a8aacec181ed6
 ./python-lib/cuddlefish/tests/linker-files/one/lib/subdir/three.js 1.0b5rc2 11aaec5fd8a4d5426d52957e1a1472a0971b42a1100fa4c5a57a8aacec181ed6
@@ -29908,6 +30226,7 @@
 ./python-lib/cuddlefish/tests/linker-files/one/lib/subdir/three.js 1.9b2 a9b3b9f3d86fd620f5b0ff0ff803419bdf16f311f4389999c3d6a7b8a84393d7
 ./python-lib/cuddlefish/tests/linker-files/one/lib/subdir/three.js 1.9b3 a9b3b9f3d86fd620f5b0ff0ff803419bdf16f311f4389999c3d6a7b8a84393d7
 ./python-lib/cuddlefish/tests/linker-files/one/lib/subdir/three.js 1.9-dev a9b3b9f3d86fd620f5b0ff0ff803419bdf16f311f4389999c3d6a7b8a84393d7
+./python-lib/cuddlefish/tests/linker-files/one/lib/subdir/three.js 1.9rc1 a9b3b9f3d86fd620f5b0ff0ff803419bdf16f311f4389999c3d6a7b8a84393d7
 ./python-lib/cuddlefish/tests/linker-files/one/lib/two.js 1.0 312e028e960db9783e6cf38fd8d8e7f13c607468446045a01ddfe9cf89f62a23
 ./python-lib/cuddlefish/tests/linker-files/one/lib/two.js 1.0b5 312e028e960db9783e6cf38fd8d8e7f13c607468446045a01ddfe9cf89f62a23
 ./python-lib/cuddlefish/tests/linker-files/one/lib/two.js 1.0b5rc2 312e028e960db9783e6cf38fd8d8e7f13c607468446045a01ddfe9cf89f62a23
@@ -29982,6 +30301,7 @@
 ./python-lib/cuddlefish/tests/linker-files/one/lib/two.js 1.9b2 801fd8f260de4770909fb53d4e220b068c77142a788c75e847cd8d7fa94916b9
 ./python-lib/cuddlefish/tests/linker-files/one/lib/two.js 1.9b3 801fd8f260de4770909fb53d4e220b068c77142a788c75e847cd8d7fa94916b9
 ./python-lib/cuddlefish/tests/linker-files/one/lib/two.js 1.9-dev 801fd8f260de4770909fb53d4e220b068c77142a788c75e847cd8d7fa94916b9
+./python-lib/cuddlefish/tests/linker-files/one/lib/two.js 1.9rc1 801fd8f260de4770909fb53d4e220b068c77142a788c75e847cd8d7fa94916b9
 ./python-lib/cuddlefish/tests/linker-files/seven/lib/main.js 1.0 7fc1a05b1d96c4af5f2468820d84008a2e37ab143d37b13fdcf7da81d92b9971
 ./python-lib/cuddlefish/tests/linker-files/seven/lib/main.js 1.0rc1 7fc1a05b1d96c4af5f2468820d84008a2e37ab143d37b13fdcf7da81d92b9971
 ./python-lib/cuddlefish/tests/linker-files/seven/lib/main.js 1.0rc2 7fc1a05b1d96c4af5f2468820d84008a2e37ab143d37b13fdcf7da81d92b9971
@@ -30054,6 +30374,7 @@
 ./python-lib/cuddlefish/tests/linker-files/seven/lib/main.js 1.9b2 441f13f2fdeea57a453f29cf1aa6615e8f66c3b780ebfac168af2516163c42b1
 ./python-lib/cuddlefish/tests/linker-files/seven/lib/main.js 1.9b3 441f13f2fdeea57a453f29cf1aa6615e8f66c3b780ebfac168af2516163c42b1
 ./python-lib/cuddlefish/tests/linker-files/seven/lib/main.js 1.9-dev 441f13f2fdeea57a453f29cf1aa6615e8f66c3b780ebfac168af2516163c42b1
+./python-lib/cuddlefish/tests/linker-files/seven/lib/main.js 1.9rc1 441f13f2fdeea57a453f29cf1aa6615e8f66c3b780ebfac168af2516163c42b1
 ./python-lib/cuddlefish/tests/linker-files/seven/lib/unused.js 1.10-dev 886c2ea79c7d1d599e9ba6eb12d6fd2d68203c8e60339592f2c52ce547f402f9
 ./python-lib/cuddlefish/tests/linker-files/seven/lib/unused.js 1.1a1 b1851c196473a114d1c24b720863e2a6033514182e3013712dcb9966f8ce1dc5
 ./python-lib/cuddlefish/tests/linker-files/seven/lib/unused.js 1.1a2 b1851c196473a114d1c24b720863e2a6033514182e3013712dcb9966f8ce1dc5
@@ -30121,6 +30442,7 @@
 ./python-lib/cuddlefish/tests/linker-files/seven/lib/unused.js 1.9b2 886c2ea79c7d1d599e9ba6eb12d6fd2d68203c8e60339592f2c52ce547f402f9
 ./python-lib/cuddlefish/tests/linker-files/seven/lib/unused.js 1.9b3 886c2ea79c7d1d599e9ba6eb12d6fd2d68203c8e60339592f2c52ce547f402f9
 ./python-lib/cuddlefish/tests/linker-files/seven/lib/unused.js 1.9-dev 886c2ea79c7d1d599e9ba6eb12d6fd2d68203c8e60339592f2c52ce547f402f9
+./python-lib/cuddlefish/tests/linker-files/seven/lib/unused.js 1.9rc1 886c2ea79c7d1d599e9ba6eb12d6fd2d68203c8e60339592f2c52ce547f402f9
 ./python-lib/cuddlefish/tests/linker-files/six/lib/unused.js 1.0 5d26b8105d76658beced852890eee871c17bf4a902975152fd41e4cab94427b4
 ./python-lib/cuddlefish/tests/linker-files/six/lib/unused.js 1.0rc1 5d26b8105d76658beced852890eee871c17bf4a902975152fd41e4cab94427b4
 ./python-lib/cuddlefish/tests/linker-files/six/lib/unused.js 1.0rc2 5d26b8105d76658beced852890eee871c17bf4a902975152fd41e4cab94427b4
@@ -30193,6 +30515,7 @@
 ./python-lib/cuddlefish/tests/linker-files/six/lib/unused.js 1.9b2 791f4ae30c44f22e09af258830427b600e8666c8beec8cef993a6c9ec0cf92d6
 ./python-lib/cuddlefish/tests/linker-files/six/lib/unused.js 1.9b3 791f4ae30c44f22e09af258830427b600e8666c8beec8cef993a6c9ec0cf92d6
 ./python-lib/cuddlefish/tests/linker-files/six/lib/unused.js 1.9-dev 791f4ae30c44f22e09af258830427b600e8666c8beec8cef993a6c9ec0cf92d6
+./python-lib/cuddlefish/tests/linker-files/six/lib/unused.js 1.9rc1 791f4ae30c44f22e09af258830427b600e8666c8beec8cef993a6c9ec0cf92d6
 ./python-lib/cuddlefish/tests/linker-files/six/unreachable.js 1.0 e3fe33253e95535c0ed030c579a7379610ae4de47a3ead9a72b2bad98d4e0457
 ./python-lib/cuddlefish/tests/linker-files/six/unreachable.js 1.0rc1 e3fe33253e95535c0ed030c579a7379610ae4de47a3ead9a72b2bad98d4e0457
 ./python-lib/cuddlefish/tests/linker-files/six/unreachable.js 1.0rc2 e3fe33253e95535c0ed030c579a7379610ae4de47a3ead9a72b2bad98d4e0457
@@ -30265,6 +30588,7 @@
 ./python-lib/cuddlefish/tests/linker-files/six/unreachable.js 1.9b2 6a2c48a35517d37388e21380648ed7699a422671814c9707c9d073c948bfa4ca
 ./python-lib/cuddlefish/tests/linker-files/six/unreachable.js 1.9b3 6a2c48a35517d37388e21380648ed7699a422671814c9707c9d073c948bfa4ca
 ./python-lib/cuddlefish/tests/linker-files/six/unreachable.js 1.9-dev 6a2c48a35517d37388e21380648ed7699a422671814c9707c9d073c948bfa4ca
+./python-lib/cuddlefish/tests/linker-files/six/unreachable.js 1.9rc1 6a2c48a35517d37388e21380648ed7699a422671814c9707c9d073c948bfa4ca
 ./python-lib/cuddlefish/tests/linker-files/three-deps/three-a/lib/main.js 1.0 a3d0b75a5e98edfafb783fce616e4a8f2bd39933eed7e52ae3a79f5e15f17823
 ./python-lib/cuddlefish/tests/linker-files/three-deps/three-a/lib/main.js 1.0rc1 a3d0b75a5e98edfafb783fce616e4a8f2bd39933eed7e52ae3a79f5e15f17823
 ./python-lib/cuddlefish/tests/linker-files/three-deps/three-a/lib/main.js 1.0rc2 a3d0b75a5e98edfafb783fce616e4a8f2bd39933eed7e52ae3a79f5e15f17823
@@ -30337,6 +30661,7 @@
 ./python-lib/cuddlefish/tests/linker-files/three-deps/three-a/lib/main.js 1.9b2 5997257f42eca62c57c6e4437a3751cc56b44d1d492a85a416f626ec91fbc7f3
 ./python-lib/cuddlefish/tests/linker-files/three-deps/three-a/lib/main.js 1.9b3 5997257f42eca62c57c6e4437a3751cc56b44d1d492a85a416f626ec91fbc7f3
 ./python-lib/cuddlefish/tests/linker-files/three-deps/three-a/lib/main.js 1.9-dev 5997257f42eca62c57c6e4437a3751cc56b44d1d492a85a416f626ec91fbc7f3
+./python-lib/cuddlefish/tests/linker-files/three-deps/three-a/lib/main.js 1.9rc1 5997257f42eca62c57c6e4437a3751cc56b44d1d492a85a416f626ec91fbc7f3
 ./python-lib/cuddlefish/tests/linker-files/three-deps/three-a/lib/subdir/subfile.js 1.10-dev 744ac8b409d4fb647a62d7bf2ecfcfea8012f533b0e0f62365f46805c5a9f34b
 ./python-lib/cuddlefish/tests/linker-files/three-deps/three-a/lib/subdir/subfile.js 1.3 1fd2f3396292bdcb01d986cd04c598a281260c6560283154d73fca29dd14f830
 ./python-lib/cuddlefish/tests/linker-files/three-deps/three-a/lib/subdir/subfile.js 1.3b1 1fd2f3396292bdcb01d986cd04c598a281260c6560283154d73fca29dd14f830
@@ -30390,6 +30715,7 @@
 ./python-lib/cuddlefish/tests/linker-files/three-deps/three-a/lib/subdir/subfile.js 1.9b2 744ac8b409d4fb647a62d7bf2ecfcfea8012f533b0e0f62365f46805c5a9f34b
 ./python-lib/cuddlefish/tests/linker-files/three-deps/three-a/lib/subdir/subfile.js 1.9b3 744ac8b409d4fb647a62d7bf2ecfcfea8012f533b0e0f62365f46805c5a9f34b
 ./python-lib/cuddlefish/tests/linker-files/three-deps/three-a/lib/subdir/subfile.js 1.9-dev 744ac8b409d4fb647a62d7bf2ecfcfea8012f533b0e0f62365f46805c5a9f34b
+./python-lib/cuddlefish/tests/linker-files/three-deps/three-a/lib/subdir/subfile.js 1.9rc1 744ac8b409d4fb647a62d7bf2ecfcfea8012f533b0e0f62365f46805c5a9f34b
 ./python-lib/cuddlefish/tests/linker-files/three-deps/three-a/lib/unused.js 1.0 92e3ca84efa6a049881b155521520ca0fb8338f7498bfbbce59e735813d3ae69
 ./python-lib/cuddlefish/tests/linker-files/three-deps/three-a/lib/unused.js 1.0rc1 92e3ca84efa6a049881b155521520ca0fb8338f7498bfbbce59e735813d3ae69
 ./python-lib/cuddlefish/tests/linker-files/three-deps/three-a/lib/unused.js 1.0rc2 92e3ca84efa6a049881b155521520ca0fb8338f7498bfbbce59e735813d3ae69
@@ -30462,6 +30788,7 @@
 ./python-lib/cuddlefish/tests/linker-files/three-deps/three-a/lib/unused.js 1.9b2 50bec7a64960b11d838f2d70a60f61b557dbbe04fa861146e710107e01fa4653
 ./python-lib/cuddlefish/tests/linker-files/three-deps/three-a/lib/unused.js 1.9b3 50bec7a64960b11d838f2d70a60f61b557dbbe04fa861146e710107e01fa4653
 ./python-lib/cuddlefish/tests/linker-files/three-deps/three-a/lib/unused.js 1.9-dev 50bec7a64960b11d838f2d70a60f61b557dbbe04fa861146e710107e01fa4653
+./python-lib/cuddlefish/tests/linker-files/three-deps/three-a/lib/unused.js 1.9rc1 50bec7a64960b11d838f2d70a60f61b557dbbe04fa861146e710107e01fa4653
 ./python-lib/cuddlefish/tests/linker-files/three-deps/three-b/lib/main.js 1.0 a3d0b75a5e98edfafb783fce616e4a8f2bd39933eed7e52ae3a79f5e15f17823
 ./python-lib/cuddlefish/tests/linker-files/three-deps/three-b/lib/main.js 1.0rc1 a3d0b75a5e98edfafb783fce616e4a8f2bd39933eed7e52ae3a79f5e15f17823
 ./python-lib/cuddlefish/tests/linker-files/three-deps/three-b/lib/main.js 1.0rc2 a3d0b75a5e98edfafb783fce616e4a8f2bd39933eed7e52ae3a79f5e15f17823
@@ -30534,6 +30861,7 @@
 ./python-lib/cuddlefish/tests/linker-files/three-deps/three-b/lib/main.js 1.9b2 e08f8b97ba1d2140799ee42f15119670400fa255b4deadfaf3dcde02244567f5
 ./python-lib/cuddlefish/tests/linker-files/three-deps/three-b/lib/main.js 1.9b3 e08f8b97ba1d2140799ee42f15119670400fa255b4deadfaf3dcde02244567f5
 ./python-lib/cuddlefish/tests/linker-files/three-deps/three-b/lib/main.js 1.9-dev e08f8b97ba1d2140799ee42f15119670400fa255b4deadfaf3dcde02244567f5
+./python-lib/cuddlefish/tests/linker-files/three-deps/three-b/lib/main.js 1.9rc1 e08f8b97ba1d2140799ee42f15119670400fa255b4deadfaf3dcde02244567f5
 ./python-lib/cuddlefish/tests/linker-files/three-deps/three-c/lib/main.js 1.0 a3d0b75a5e98edfafb783fce616e4a8f2bd39933eed7e52ae3a79f5e15f17823
 ./python-lib/cuddlefish/tests/linker-files/three-deps/three-c/lib/main.js 1.0rc1 a3d0b75a5e98edfafb783fce616e4a8f2bd39933eed7e52ae3a79f5e15f17823
 ./python-lib/cuddlefish/tests/linker-files/three-deps/three-c/lib/main.js 1.0rc2 a3d0b75a5e98edfafb783fce616e4a8f2bd39933eed7e52ae3a79f5e15f17823
@@ -30606,6 +30934,7 @@
 ./python-lib/cuddlefish/tests/linker-files/three-deps/three-c/lib/main.js 1.9b2 e08f8b97ba1d2140799ee42f15119670400fa255b4deadfaf3dcde02244567f5
 ./python-lib/cuddlefish/tests/linker-files/three-deps/three-c/lib/main.js 1.9b3 e08f8b97ba1d2140799ee42f15119670400fa255b4deadfaf3dcde02244567f5
 ./python-lib/cuddlefish/tests/linker-files/three-deps/three-c/lib/main.js 1.9-dev e08f8b97ba1d2140799ee42f15119670400fa255b4deadfaf3dcde02244567f5
+./python-lib/cuddlefish/tests/linker-files/three-deps/three-c/lib/main.js 1.9rc1 e08f8b97ba1d2140799ee42f15119670400fa255b4deadfaf3dcde02244567f5
 ./python-lib/cuddlefish/tests/linker-files/three-deps/three-c/lib/sub/foo.js 1.0 149146e0beb77c15c78d43cbba67898cff71ad01f29c526138b02d43bafe2b5c
 ./python-lib/cuddlefish/tests/linker-files/three-deps/three-c/lib/sub/foo.js 1.0rc1 149146e0beb77c15c78d43cbba67898cff71ad01f29c526138b02d43bafe2b5c
 ./python-lib/cuddlefish/tests/linker-files/three-deps/three-c/lib/sub/foo.js 1.0rc2 149146e0beb77c15c78d43cbba67898cff71ad01f29c526138b02d43bafe2b5c
@@ -30678,6 +31007,7 @@
 ./python-lib/cuddlefish/tests/linker-files/three-deps/three-c/lib/sub/foo.js 1.9b2 78c3503603ede662f8fafceedc18fca0b4a48e2f016989c643683074d1cf4c98
 ./python-lib/cuddlefish/tests/linker-files/three-deps/three-c/lib/sub/foo.js 1.9b3 78c3503603ede662f8fafceedc18fca0b4a48e2f016989c643683074d1cf4c98
 ./python-lib/cuddlefish/tests/linker-files/three-deps/three-c/lib/sub/foo.js 1.9-dev 78c3503603ede662f8fafceedc18fca0b4a48e2f016989c643683074d1cf4c98
+./python-lib/cuddlefish/tests/linker-files/three-deps/three-c/lib/sub/foo.js 1.9rc1 78c3503603ede662f8fafceedc18fca0b4a48e2f016989c643683074d1cf4c98
 ./python-lib/cuddlefish/tests/linker-files/three/lib/main.js 1.0 5e5899f05d440494e423c53696741a4c93baa4f671b66f0a326af78c6b5c9753
 ./python-lib/cuddlefish/tests/linker-files/three/lib/main.js 1.0rc1 5e5899f05d440494e423c53696741a4c93baa4f671b66f0a326af78c6b5c9753
 ./python-lib/cuddlefish/tests/linker-files/three/lib/main.js 1.0rc2 5e5899f05d440494e423c53696741a4c93baa4f671b66f0a326af78c6b5c9753
@@ -30750,6 +31080,7 @@
 ./python-lib/cuddlefish/tests/linker-files/three/lib/main.js 1.9b2 9132ebc55856415307138c971d9dc771ccb2bd51f8400cceea9667b00196b31b
 ./python-lib/cuddlefish/tests/linker-files/three/lib/main.js 1.9b3 9132ebc55856415307138c971d9dc771ccb2bd51f8400cceea9667b00196b31b
 ./python-lib/cuddlefish/tests/linker-files/three/lib/main.js 1.9-dev 9132ebc55856415307138c971d9dc771ccb2bd51f8400cceea9667b00196b31b
+./python-lib/cuddlefish/tests/linker-files/three/lib/main.js 1.9rc1 9132ebc55856415307138c971d9dc771ccb2bd51f8400cceea9667b00196b31b
 ./python-lib/cuddlefish/tests/linker-files/three/tests/nontest.js 1.10-dev 1b8e4c1fcba9720a10a7b6fe548069b30b5c0a2992b077561179f3ef17cd811e
 ./python-lib/cuddlefish/tests/linker-files/three/tests/nontest.js 1.5b3 ce1de9e6265413a3c330a4f5adb51eb9019a37a3966c5c43381124efefce3217
 ./python-lib/cuddlefish/tests/linker-files/three/tests/nontest.js 1.5 ce1de9e6265413a3c330a4f5adb51eb9019a37a3966c5c43381124efefce3217
@@ -30782,6 +31113,7 @@
 ./python-lib/cuddlefish/tests/linker-files/three/tests/nontest.js 1.9b2 1b8e4c1fcba9720a10a7b6fe548069b30b5c0a2992b077561179f3ef17cd811e
 ./python-lib/cuddlefish/tests/linker-files/three/tests/nontest.js 1.9b3 1b8e4c1fcba9720a10a7b6fe548069b30b5c0a2992b077561179f3ef17cd811e
 ./python-lib/cuddlefish/tests/linker-files/three/tests/nontest.js 1.9-dev 1b8e4c1fcba9720a10a7b6fe548069b30b5c0a2992b077561179f3ef17cd811e
+./python-lib/cuddlefish/tests/linker-files/three/tests/nontest.js 1.9rc1 1b8e4c1fcba9720a10a7b6fe548069b30b5c0a2992b077561179f3ef17cd811e
 ./python-lib/cuddlefish/tests/linker-files/three/tests/test-one.js 1.10-dev 1b8e4c1fcba9720a10a7b6fe548069b30b5c0a2992b077561179f3ef17cd811e
 ./python-lib/cuddlefish/tests/linker-files/three/tests/test-one.js 1.5b3 ce1de9e6265413a3c330a4f5adb51eb9019a37a3966c5c43381124efefce3217
 ./python-lib/cuddlefish/tests/linker-files/three/tests/test-one.js 1.5 ce1de9e6265413a3c330a4f5adb51eb9019a37a3966c5c43381124efefce3217
@@ -30814,6 +31146,7 @@
 ./python-lib/cuddlefish/tests/linker-files/three/tests/test-one.js 1.9b2 1b8e4c1fcba9720a10a7b6fe548069b30b5c0a2992b077561179f3ef17cd811e
 ./python-lib/cuddlefish/tests/linker-files/three/tests/test-one.js 1.9b3 1b8e4c1fcba9720a10a7b6fe548069b30b5c0a2992b077561179f3ef17cd811e
 ./python-lib/cuddlefish/tests/linker-files/three/tests/test-one.js 1.9-dev 1b8e4c1fcba9720a10a7b6fe548069b30b5c0a2992b077561179f3ef17cd811e
+./python-lib/cuddlefish/tests/linker-files/three/tests/test-one.js 1.9rc1 1b8e4c1fcba9720a10a7b6fe548069b30b5c0a2992b077561179f3ef17cd811e
 ./python-lib/cuddlefish/tests/linker-files/three/tests/test-two.js 1.10-dev 1b8e4c1fcba9720a10a7b6fe548069b30b5c0a2992b077561179f3ef17cd811e
 ./python-lib/cuddlefish/tests/linker-files/three/tests/test-two.js 1.5b3 ce1de9e6265413a3c330a4f5adb51eb9019a37a3966c5c43381124efefce3217
 ./python-lib/cuddlefish/tests/linker-files/three/tests/test-two.js 1.5 ce1de9e6265413a3c330a4f5adb51eb9019a37a3966c5c43381124efefce3217
@@ -30846,6 +31179,7 @@
 ./python-lib/cuddlefish/tests/linker-files/three/tests/test-two.js 1.9b2 1b8e4c1fcba9720a10a7b6fe548069b30b5c0a2992b077561179f3ef17cd811e
 ./python-lib/cuddlefish/tests/linker-files/three/tests/test-two.js 1.9b3 1b8e4c1fcba9720a10a7b6fe548069b30b5c0a2992b077561179f3ef17cd811e
 ./python-lib/cuddlefish/tests/linker-files/three/tests/test-two.js 1.9-dev 1b8e4c1fcba9720a10a7b6fe548069b30b5c0a2992b077561179f3ef17cd811e
+./python-lib/cuddlefish/tests/linker-files/three/tests/test-two.js 1.9rc1 1b8e4c1fcba9720a10a7b6fe548069b30b5c0a2992b077561179f3ef17cd811e
 ./python-lib/cuddlefish/tests/preferences-files/packages/no-prefs/lib/main.js 1.10-dev fbb692bbd64e4c5c7905421273af7318775a626e736435ba4b8ea725bc20ce87
 ./python-lib/cuddlefish/tests/preferences-files/packages/no-prefs/lib/main.js 1.4.1 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 ./python-lib/cuddlefish/tests/preferences-files/packages/no-prefs/lib/main.js 1.4.2 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
@@ -30894,6 +31228,7 @@
 ./python-lib/cuddlefish/tests/preferences-files/packages/no-prefs/lib/main.js 1.9b2 fbb692bbd64e4c5c7905421273af7318775a626e736435ba4b8ea725bc20ce87
 ./python-lib/cuddlefish/tests/preferences-files/packages/no-prefs/lib/main.js 1.9b3 fbb692bbd64e4c5c7905421273af7318775a626e736435ba4b8ea725bc20ce87
 ./python-lib/cuddlefish/tests/preferences-files/packages/no-prefs/lib/main.js 1.9-dev fbb692bbd64e4c5c7905421273af7318775a626e736435ba4b8ea725bc20ce87
+./python-lib/cuddlefish/tests/preferences-files/packages/no-prefs/lib/main.js 1.9rc1 fbb692bbd64e4c5c7905421273af7318775a626e736435ba4b8ea725bc20ce87
 ./python-lib/cuddlefish/tests/preferences-files/packages/simple-prefs/lib/main.js 1.10-dev fbb692bbd64e4c5c7905421273af7318775a626e736435ba4b8ea725bc20ce87
 ./python-lib/cuddlefish/tests/preferences-files/packages/simple-prefs/lib/main.js 1.4.1 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 ./python-lib/cuddlefish/tests/preferences-files/packages/simple-prefs/lib/main.js 1.4.2 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
@@ -30942,6 +31277,7 @@
 ./python-lib/cuddlefish/tests/preferences-files/packages/simple-prefs/lib/main.js 1.9b2 fbb692bbd64e4c5c7905421273af7318775a626e736435ba4b8ea725bc20ce87
 ./python-lib/cuddlefish/tests/preferences-files/packages/simple-prefs/lib/main.js 1.9b3 fbb692bbd64e4c5c7905421273af7318775a626e736435ba4b8ea725bc20ce87
 ./python-lib/cuddlefish/tests/preferences-files/packages/simple-prefs/lib/main.js 1.9-dev fbb692bbd64e4c5c7905421273af7318775a626e736435ba4b8ea725bc20ce87
+./python-lib/cuddlefish/tests/preferences-files/packages/simple-prefs/lib/main.js 1.9rc1 fbb692bbd64e4c5c7905421273af7318775a626e736435ba4b8ea725bc20ce87
 ./python-lib/cuddlefish/tests/static-files/docs/APIreference.html 1.0 4139e78595003bc386dfaab5e3095b495d0ada94b821b6b0b0afb09de3c55b35
 ./python-lib/cuddlefish/tests/static-files/docs/APIreference.html 1.0b2 5b6d26206be09b3b03741c39e05f40dc7a5d2405b90d7fbffd2519cad6f1e73a
 ./python-lib/cuddlefish/tests/static-files/docs/APIreference.html 1.0b2rc1 5b6d26206be09b3b03741c39e05f40dc7a5d2405b90d7fbffd2519cad6f1e73a
@@ -31028,6 +31364,7 @@
 ./python-lib/cuddlefish/tests/static-files/docs/APIreference.html 1.9b2 e1b077faa805977e466cea2c211544d804fc7e510d04692ca9ababa52ef02bf9
 ./python-lib/cuddlefish/tests/static-files/docs/APIreference.html 1.9b3 e1b077faa805977e466cea2c211544d804fc7e510d04692ca9ababa52ef02bf9
 ./python-lib/cuddlefish/tests/static-files/docs/APIreference.html 1.9-dev e1b077faa805977e466cea2c211544d804fc7e510d04692ca9ababa52ef02bf9
+./python-lib/cuddlefish/tests/static-files/docs/APIreference.html 1.9rc1 e1b077faa805977e466cea2c211544d804fc7e510d04692ca9ababa52ef02bf9
 ./python-lib/cuddlefish/tests/static-files/doc/static-files/another.html 1.10-dev 98566bc9227c2f0b6987c24e476f6225fd9233a8e187f48d7779c25b44991cf6
 ./python-lib/cuddlefish/tests/static-files/doc/static-files/another.html 1.3 100ef6a71bac925f709fe9c114c60460bf6e472cfdb9d44bd8adf1698135260f
 ./python-lib/cuddlefish/tests/static-files/doc/static-files/another.html 1.3rc1 100ef6a71bac925f709fe9c114c60460bf6e472cfdb9d44bd8adf1698135260f
@@ -31078,6 +31415,7 @@
 ./python-lib/cuddlefish/tests/static-files/doc/static-files/another.html 1.9b2 98566bc9227c2f0b6987c24e476f6225fd9233a8e187f48d7779c25b44991cf6
 ./python-lib/cuddlefish/tests/static-files/doc/static-files/another.html 1.9b3 98566bc9227c2f0b6987c24e476f6225fd9233a8e187f48d7779c25b44991cf6
 ./python-lib/cuddlefish/tests/static-files/doc/static-files/another.html 1.9-dev 98566bc9227c2f0b6987c24e476f6225fd9233a8e187f48d7779c25b44991cf6
+./python-lib/cuddlefish/tests/static-files/doc/static-files/another.html 1.9rc1 98566bc9227c2f0b6987c24e476f6225fd9233a8e187f48d7779c25b44991cf6
 ./python-lib/cuddlefish/tests/static-files/doc/static-files/base.html 1.10-dev 4f1a74f128b2f4a3d0bf63c7e5c7b99593c6d073907cbb04a889e400b0402d89
 ./python-lib/cuddlefish/tests/static-files/doc/static-files/base.html 1.2.1 c225f5cc10c3bdc7de3087a72286eca9035613b125d2fd6d115f95bf109edb59
 ./python-lib/cuddlefish/tests/static-files/doc/static-files/base.html 1.2.1rc1 c225f5cc10c3bdc7de3087a72286eca9035613b125d2fd6d115f95bf109edb59
@@ -31139,6 +31477,7 @@
 ./python-lib/cuddlefish/tests/static-files/doc/static-files/base.html 1.9b2 4f1a74f128b2f4a3d0bf63c7e5c7b99593c6d073907cbb04a889e400b0402d89
 ./python-lib/cuddlefish/tests/static-files/doc/static-files/base.html 1.9b3 4f1a74f128b2f4a3d0bf63c7e5c7b99593c6d073907cbb04a889e400b0402d89
 ./python-lib/cuddlefish/tests/static-files/doc/static-files/base.html 1.9-dev 4f1a74f128b2f4a3d0bf63c7e5c7b99593c6d073907cbb04a889e400b0402d89
+./python-lib/cuddlefish/tests/static-files/doc/static-files/base.html 1.9rc1 4f1a74f128b2f4a3d0bf63c7e5c7b99593c6d073907cbb04a889e400b0402d89
 ./python-lib/cuddlefish/tests/static-files/doc/static-files/index.html 1.10-dev d26cd6e1fdba66aa00a6b38eed09b01ce6c0d6653c85c911db2db48391e92d62
 ./python-lib/cuddlefish/tests/static-files/doc/static-files/index.html 1.2.1 603972ff10b28436a16afade5e90d26e120db74d3a535b94ab8f10af6acd5da1
 ./python-lib/cuddlefish/tests/static-files/doc/static-files/index.html 1.2.1rc1 603972ff10b28436a16afade5e90d26e120db74d3a535b94ab8f10af6acd5da1
@@ -31200,6 +31539,7 @@
 ./python-lib/cuddlefish/tests/static-files/doc/static-files/index.html 1.9b2 d26cd6e1fdba66aa00a6b38eed09b01ce6c0d6653c85c911db2db48391e92d62
 ./python-lib/cuddlefish/tests/static-files/doc/static-files/index.html 1.9b3 d26cd6e1fdba66aa00a6b38eed09b01ce6c0d6653c85c911db2db48391e92d62
 ./python-lib/cuddlefish/tests/static-files/doc/static-files/index.html 1.9-dev d26cd6e1fdba66aa00a6b38eed09b01ce6c0d6653c85c911db2db48391e92d62
+./python-lib/cuddlefish/tests/static-files/doc/static-files/index.html 1.9rc1 d26cd6e1fdba66aa00a6b38eed09b01ce6c0d6653c85c911db2db48391e92d62
 ./python-lib/cuddlefish/tests/static-files/packages/aardvark/lib/main.js 0.3 a592cf3cf924f2c77e0728d97131138fcb7495c77f5202ac55c2e0c77ef903c2
 ./python-lib/cuddlefish/tests/static-files/packages/aardvark/lib/main.js 0.3rc1 a592cf3cf924f2c77e0728d97131138fcb7495c77f5202ac55c2e0c77ef903c2
 ./python-lib/cuddlefish/tests/static-files/packages/aardvark/lib/main.js 0.3rc2 a592cf3cf924f2c77e0728d97131138fcb7495c77f5202ac55c2e0c77ef903c2
@@ -31314,6 +31654,7 @@
 ./python-lib/cuddlefish/tests/static-files/packages/aardvark/lib/main.js 1.9b2 1ad29f7a17704b6e60cf973e597ad15914b0448dd4b14ba90bbbfc223c8a5ee3
 ./python-lib/cuddlefish/tests/static-files/packages/aardvark/lib/main.js 1.9b3 1ad29f7a17704b6e60cf973e597ad15914b0448dd4b14ba90bbbfc223c8a5ee3
 ./python-lib/cuddlefish/tests/static-files/packages/aardvark/lib/main.js 1.9-dev 1ad29f7a17704b6e60cf973e597ad15914b0448dd4b14ba90bbbfc223c8a5ee3
+./python-lib/cuddlefish/tests/static-files/packages/aardvark/lib/main.js 1.9rc1 1ad29f7a17704b6e60cf973e597ad15914b0448dd4b14ba90bbbfc223c8a5ee3
 ./python-lib/cuddlefish/tests/static-files/packages/anteater_files/lib/main.js 1.10-dev 1ad29f7a17704b6e60cf973e597ad15914b0448dd4b14ba90bbbfc223c8a5ee3
 ./python-lib/cuddlefish/tests/static-files/packages/anteater_files/lib/main.js 1.3 a592cf3cf924f2c77e0728d97131138fcb7495c77f5202ac55c2e0c77ef903c2
 ./python-lib/cuddlefish/tests/static-files/packages/anteater_files/lib/main.js 1.3b1 a592cf3cf924f2c77e0728d97131138fcb7495c77f5202ac55c2e0c77ef903c2
@@ -31367,6 +31708,7 @@
 ./python-lib/cuddlefish/tests/static-files/packages/anteater_files/lib/main.js 1.9b2 1ad29f7a17704b6e60cf973e597ad15914b0448dd4b14ba90bbbfc223c8a5ee3
 ./python-lib/cuddlefish/tests/static-files/packages/anteater_files/lib/main.js 1.9b3 1ad29f7a17704b6e60cf973e597ad15914b0448dd4b14ba90bbbfc223c8a5ee3
 ./python-lib/cuddlefish/tests/static-files/packages/anteater_files/lib/main.js 1.9-dev 1ad29f7a17704b6e60cf973e597ad15914b0448dd4b14ba90bbbfc223c8a5ee3
+./python-lib/cuddlefish/tests/static-files/packages/anteater_files/lib/main.js 1.9rc1 1ad29f7a17704b6e60cf973e597ad15914b0448dd4b14ba90bbbfc223c8a5ee3
 ./python-lib/cuddlefish/tests/static-files/packages/api-utils/lib/loader.js 1.0b1 efac9dc700a56e693ac75ab81955c11e6874ddc83d92c11177d643601eaac346
 ./python-lib/cuddlefish/tests/static-files/packages/api-utils/lib/loader.js 1.0b1rc1 efac9dc700a56e693ac75ab81955c11e6874ddc83d92c11177d643601eaac346
 ./python-lib/cuddlefish/tests/static-files/packages/api-utils/lib/loader.js 1.0b1rc2 efac9dc700a56e693ac75ab81955c11e6874ddc83d92c11177d643601eaac346
@@ -31458,6 +31800,7 @@
 ./python-lib/cuddlefish/tests/static-files/packages/api-utils/lib/loader.js 1.9b2 b1e84998738071bedf2c0dde87ec8e4725db92ad19cc754b2eb417f35c0f8695
 ./python-lib/cuddlefish/tests/static-files/packages/api-utils/lib/loader.js 1.9b3 b1e84998738071bedf2c0dde87ec8e4725db92ad19cc754b2eb417f35c0f8695
 ./python-lib/cuddlefish/tests/static-files/packages/api-utils/lib/loader.js 1.9-dev b1e84998738071bedf2c0dde87ec8e4725db92ad19cc754b2eb417f35c0f8695
+./python-lib/cuddlefish/tests/static-files/packages/api-utils/lib/loader.js 1.9rc1 b1e84998738071bedf2c0dde87ec8e4725db92ad19cc754b2eb417f35c0f8695
 ./python-lib/cuddlefish/tests/static-files/packages/barbeque/lib/bar-module.js 0.3 2515f8623e793571f1dffc4828de14a00a3da9be666147f8cebb3b3f1929e4d6
 ./python-lib/cuddlefish/tests/static-files/packages/barbeque/lib/bar-module.js 0.3rc1 2515f8623e793571f1dffc4828de14a00a3da9be666147f8cebb3b3f1929e4d6
 ./python-lib/cuddlefish/tests/static-files/packages/barbeque/lib/bar-module.js 0.3rc2 2515f8623e793571f1dffc4828de14a00a3da9be666147f8cebb3b3f1929e4d6
@@ -31572,6 +31915,7 @@
 ./python-lib/cuddlefish/tests/static-files/packages/barbeque/lib/bar-module.js 1.9b2 ff4ba2a3fd150a75f8d98ce2d78c89012bc00c0d02ecd56555e712b02774f03b
 ./python-lib/cuddlefish/tests/static-files/packages/barbeque/lib/bar-module.js 1.9b3 ff4ba2a3fd150a75f8d98ce2d78c89012bc00c0d02ecd56555e712b02774f03b
 ./python-lib/cuddlefish/tests/static-files/packages/barbeque/lib/bar-module.js 1.9-dev ff4ba2a3fd150a75f8d98ce2d78c89012bc00c0d02ecd56555e712b02774f03b
+./python-lib/cuddlefish/tests/static-files/packages/barbeque/lib/bar-module.js 1.9rc1 ff4ba2a3fd150a75f8d98ce2d78c89012bc00c0d02ecd56555e712b02774f03b
 ./python-lib/cuddlefish/tests/static-files/packages/bar/lib/bar-module.js 0.2 2515f8623e793571f1dffc4828de14a00a3da9be666147f8cebb3b3f1929e4d6
 ./python-lib/cuddlefish/tests/static-files/packages/bar/lib/bar-module.js 0.2rc1 2515f8623e793571f1dffc4828de14a00a3da9be666147f8cebb3b3f1929e4d6
 ./python-lib/cuddlefish/tests/static-files/packages/bar/lib/bar-module.js 0.2rc2 2515f8623e793571f1dffc4828de14a00a3da9be666147f8cebb3b3f1929e4d6
@@ -31686,6 +32030,7 @@
 ./python-lib/cuddlefish/tests/static-files/packages/minimal/lib/main.js 1.9b2 ceb04288fd0191fb07d161bfb8973ccea6ed1c005b8ad361e6d9ae7289333d83
 ./python-lib/cuddlefish/tests/static-files/packages/minimal/lib/main.js 1.9b3 ceb04288fd0191fb07d161bfb8973ccea6ed1c005b8ad361e6d9ae7289333d83
 ./python-lib/cuddlefish/tests/static-files/packages/minimal/lib/main.js 1.9-dev ceb04288fd0191fb07d161bfb8973ccea6ed1c005b8ad361e6d9ae7289333d83
+./python-lib/cuddlefish/tests/static-files/packages/minimal/lib/main.js 1.9rc1 ceb04288fd0191fb07d161bfb8973ccea6ed1c005b8ad361e6d9ae7289333d83
 ./python-lib/cuddlefish/tests/static-files/static-files/base.html 1.0 9fcbe27573c189477fa1cdbabd45e1cfb4f61b147df5824de53253a258ae569e
 ./python-lib/cuddlefish/tests/static-files/static-files/base.html 1.0b3 4a2b3701b5407e0e6ca9296c7e9d967116fa5580237dbf3d4dbbc70084fb1999
 ./python-lib/cuddlefish/tests/static-files/static-files/base.html 1.0b3rc1 4a2b3701b5407e0e6ca9296c7e9d967116fa5580237dbf3d4dbbc70084fb1999
@@ -31849,6 +32194,7 @@
 ./python-lib/cuddlefish/tests/static-files/xpi-template/components/harness.js 1.9b2 1ee0467e75bde913c96cee5711c4c61d049b7a676e459a7d0a09c1b52044f71a
 ./python-lib/cuddlefish/tests/static-files/xpi-template/components/harness.js 1.9b3 1ee0467e75bde913c96cee5711c4c61d049b7a676e459a7d0a09c1b52044f71a
 ./python-lib/cuddlefish/tests/static-files/xpi-template/components/harness.js 1.9-dev 1ee0467e75bde913c96cee5711c4c61d049b7a676e459a7d0a09c1b52044f71a
+./python-lib/cuddlefish/tests/static-files/xpi-template/components/harness.js 1.9rc1 1ee0467e75bde913c96cee5711c4c61d049b7a676e459a7d0a09c1b52044f71a
 ./static-files/base.html 1.0 1af31702458eaa11d38f98562b8ee2a7bd6ea91632c6eaccff1452669460e9a9
 ./static-files/base.html 1.0b3 493f5ce5326bf56100bdbb94b4fdfb053c841fede9b75455f7d31fc005794c42
 ./static-files/base.html 1.0b3rc1 493f5ce5326bf56100bdbb94b4fdfb053c841fede9b75455f7d31fc005794c42


### PR DESCRIPTION
We're going to be shipping SDK 1.9 next week, which should hopefully be identical to the recently created 1.9rc1. 

If I understand the validator correctly, addons submitted with the final 1.9 SDK (if no changes have to go into it in the next week) should match the hashes from 1.9rc1, so they should be accepted with this pull request merged.

So if this could get landed this week, it'll make next week's release a bit easier.
