### PR TITLE
Removed the requirement to have a locales with a default_locale (bug 777325)

### DIFF
--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -204,7 +204,6 @@ class TestWebapps(TestCase):
 
     def test_no_locales(self):
         """Test that locales are not required."""
-        del self.data["default_locale"]
         del self.data["locales"]
         self.analyze()
         self.assert_silent()

--- a/validator/specs/webapps.py
+++ b/validator/specs/webapps.py
@@ -53,7 +53,6 @@ class WebappSpec(Spec):
                  "child_nodes": {"*": {"expected_type": dict,
                                        "child_nodes": {}}}},  # Set in __init__
             "default_locale": {"expected_type": types.StringTypes,
-                               "process": lambda s: s.process_default_locale,
                                "not_empty": True},
             "installs_allowed_from": {"expected_type": list,
                                       "process": lambda s: s.process_iaf,
@@ -198,15 +197,6 @@ class WebappSpec(Spec):
                 description=["`url`s provided for the `developer` element must "
                              "be full URLs (including the protocol).",
                              "Found: %s" % node,
-                             self.MORE_INFO])
-
-    def process_default_locale(self, node):
-        if "locales" not in self.data:
-            self.err.error(
-                err_id=("spec", "webapp", "def_locale_wo_locales"),
-                error="`default_locale` without `locales`",
-                description=["A `default_locale` was provided without a "
-                             "`locales` node.",
                              self.MORE_INFO])
 
     def process_iaf(self, node):


### PR DESCRIPTION
The spec makes no mention that locales is a requirement if default_locale exists.  The requirement is the other way around (which is dealt with here: https://github.com/eviljeff/amo-validator/blob/4e22fcb2b7f9ddb483babfa91462163fb97f84b5/validator/specs/webapps.py#L20 instead)
