### PR TITLE
Fix: Spidermonkey dropped --utf8 flag

### DIFF
--- a/validator/testcases/javascript/spidermonkey.py
+++ b/validator/testcases/javascript/spidermonkey.py
@@ -111,6 +111,15 @@ def _get_tree(code, shell):
                                      stdout=subprocess.PIPE)
 
         data, stderr = shell_obj.communicate()
+        # Spidermonkey dropped the -U flag on 29 Oct 2012
+        if stderr and "Invalid short option: -U" in stderr:
+            cmd.remove("-U")
+            shell_obj = subprocess.Popen(cmd,
+                                         shell=False,
+                                         stderr=subprocess.PIPE,
+                                         stdout=subprocess.PIPE)
+
+            data, stderr = shell_obj.communicate()
         if stderr and not data:
             raise RuntimeError('Error calling %r: %s' % (cmd, stderr))
 


### PR DESCRIPTION
## Issue

Four months ago, Spidermonkey dropped the `-U` (`--utf8`) flag (see [commit 53c97](https://github.com/mozilla/mozilla-central/commit/53c97c#L16L4876)).  
Consequently,  `amo-validator` fails when the latest Spidermonkey binary is installed, because it returns the usage string (like `js --help`) and puts "Invalid short option: -U\n\n" in `stderr`.
## Patch

This patch fixes the bug while remaining backwards-compatible. If backward-compatibility is not an issue, the solution can be simplified to removing `, '-U'` from [line 170](https://github.com/mozilla/amo-validator/blob/3bd2c/validator/testcases/javascript/spidermonkey.py#L107).
## Steps to reproduce
1. Get a recent Spidermonkey binary (eg. a [nightly build of jsshell](http://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/latest-trunk/))
2. Run `addon-validator whatever-extension.xpi`
3. Result:

```
Traceback (most recent call last):
  File "/tmp/amo-validator/addon-validator", line 6, in <module>
    validator.main.main()
  File "/tmp/amo-validator/validator/main.py", line 133, in main
    timeout=timeout)
  File "/tmp/amo-validator/validator/validate.py", line 82, in validate
    timeout=timeout)
  File "/tmp/amo-validator/validator/submain.py", line 92, in prepare_package
    for_appversions)
  File "/tmp/amo-validator/validator/submain.py", line 160, in test_package
    output = test_inner_package(err, package, for_appversions)
  File "/tmp/amo-validator/validator/submain.py", line 338, in test_inner_package
    test_func(err, xpi_package)
  File "/tmp/amo-validator/validator/testcases/content.py", line 246, in test_packed_scripts
    pollutable=reversed_script in marked_scripts)
  File "/tmp/amo-validator/validator/testcases/scripting.py", line 43, in test_js_file
    tree = get_tree(data, filename=filename, shell=spidermonkey, err=err)
  File "/tmp/amo-validator/validator/testcases/javascript/spidermonkey.py", line 22, in get_tree
    return _get_tree(code, shell)
  File "/tmp/amo-validator/validator/testcases/javascript/spidermonkey.py", line 129, in _get_tree
    parsed = json.loads(data, strict=False)
  File "/usr/lib/python2.7/site-packages/simplejson/__init__.py", line 430, in loads
    return cls(encoding=encoding, **kw).decode(s)
  File "/usr/lib/python2.7/site-packages/simplejson/decoder.py", line 402, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python2.7/site-packages/simplejson/decoder.py", line 420, in raw_decode
    raise JSONDecodeError("No JSON object could be decoded", s, idx)
simplejson.decoder.JSONDecodeError: No JSON object could be decoded: line 1 column 0 (char 0)
```
