### PR TITLE
only log the downloads-indicator error for FF27 (bug 965156)

### DIFF
--- a/tests/test_markup_csstester.py
+++ b/tests/test_markup_csstester.py
@@ -108,6 +108,16 @@ def test_unprefixed_patterns_unchanged():
     yield test_descriptor, "calc"
 
 
+def test_downloads_indicator_gecko_16():
+    """Test that #downloads-indicator is allowed for an old Gecko."""
+
+    err = ErrorBundle(for_appversions=FX16_DEFINITION)
+    csstester.test_css_file(err, "x.css",
+                            "#downloads-indicator { display: none; }", 0)
+    assert not err.failed()
+    assert all(val == 0 for val in err.compat_summary.values())
+
+
 def test_downloads_indicator_unused():
     """Test that #downloads-indicator is not used."""
 

--- a/validator/testcases/markup/csstester.py
+++ b/validator/testcases/markup/csstester.py
@@ -2,7 +2,7 @@ import re
 from functools import partial
 import cssutils
 
-from validator.compat import FX16_DEFINITION
+from validator.compat import FX16_DEFINITION, FX27_DEFINITION
 from validator.constants import BUGZILLA_BUG, PACKAGE_THEME
 from validator.contextgenerator import ContextGenerator
 
@@ -172,7 +172,8 @@ def _run_css_tests(err, tokens, filename, line_start=0, context=None):
                    % BUGZILLA_BUG % DOWNLOADS_INDICATOR_BUG,
                    "Lines: %s" % ", ".join(downloads_indicator_selectors)],
                   filename,
-                  compatibility_type="error")
+                  compatibility_type="error",
+                  for_appversions=FX27_DEFINITION)
 
 
 UNPREFIXED_WARNING = "`%s` is no longer prefixed in Gecko 16."


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=965156

If you use `#downloads-indicator` you'll get an error on FF 27, but not 26 anymore.
