### PR TITLE
Traverse yield expressions (bug 1036556)

### DIFF
--- a/tests/compat/test_gecko31.py
+++ b/tests/compat/test_gecko31.py
@@ -19,6 +19,15 @@ class TestFX31Compat(CompatTestCase):
         self.assert_silent()
         self.assert_compat_error()
 
+    def test_getShortcutOrURIAndPostData_promise_yield(self):
+        self.run_script_for_compat('''
+            function urlAndPostData() {
+                yield getShortcutOrURIAndPostData("a string");
+            }
+        ''')
+        self.assert_silent()
+        self.assert_compat_error()
+
     def test_getShortcutOrURIAndPostData_promise_window(self):
         self.run_script_for_compat(
             'var p = window.getShortcutOrURIAndPostData("something");')

--- a/validator/testcases/javascript/nodedefinitions.py
+++ b/validator/testcases/javascript/nodedefinitions.py
@@ -75,7 +75,7 @@ DEFINITIONS = {
                            action=actions._call_expression, returns=True),
     "MemberExpression": node(branches=("object", "property"),
                              action=actions.trace_member, returns=True),
-    "YieldExpression": node(branches=("argument"), returns=True),
+    "YieldExpression": node(branches=("argument",), returns=True),
     "ComprehensionExpression": node(branches=("body", "filter"), returns=True),
     "GeneratorExpression": node(branches=("body", "filter"), returns=True),
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1036556

I couldn't find a good way to test this in [tests/js/test_traversal.js](https://github.com/mozilla/amo-validator/blob/master/tests/js/test_traversal.py) since so I just used the test that verified the bug.
