### PR TITLE
release 1.4.6 to pypi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 sudo: false
 python:
-  - "2.6"
+  - '2.6'
 env:
   - TOX_ENV=py26
   - TOX_ENV=py27
@@ -16,6 +16,15 @@ script:
 notifications:
   irc:
     channels:
-      - "irc.mozilla.org#amo-bots"
+      - irc.mozilla.org#amo-bots
     on_success: change
     on_failure: always
+deploy:
+  provider: pypi
+  user: marketplacedevsinternal
+  password:
+    secure: kYcPvTPRAPw4lXKgHqEPQr/df6+MppYn30u4POo/uciefp7362FP/88KU4fV87fo+6gwFuHktsVtCiYAOmQp/d0ajhqLv3ZIDGYr9kesFl5CtRuh/LDsx1Matasm0BKDepqY02r9eMJV0FweB9Lpz0vw79Ow6cgU2CH7f9GfgY4=
+  on:
+    tags: true
+    all-branches: true
+  distributions: "sdist bdist_wheel"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='amo-validator',
-    version='1.1',
+    version='1.4.6',
     description='Validates add-ons for Mozilla products.',
     long_description=open('README.md').read(),
     author='Matt Basta',


### PR DESCRIPTION
I chose to release 1.4.6, which is the next logical version when you look at
the tags, and not 1.1, which is the next logical version when you look at the
current version on pypi.