### PR TITLE
Signature files got renamed from zigbert to mozilla (bug 1070188)

### DIFF
--- a/tests/test_signed_xpi.py
+++ b/tests/test_signed_xpi.py
@@ -22,8 +22,8 @@ def test_signed_xpi():
     """Test that signed packages raise warning"""
     x = MockXPI({
         'META-INF/manifest.mf': 'tests/resources/main/foo.bar',
-        'META-INF/zigbert.rsa': 'tests/resources/main/foo.bar',
-        'META-INF/zigbert.sf': 'tests/resources/main/foo.bar',
+        'META-INF/mozilla.rsa': 'tests/resources/main/foo.bar',
+        'META-INF/mozilla.sf': 'tests/resources/main/foo.bar',
     })
 
     err = ErrorBundle()

--- a/validator/testcases/content.py
+++ b/validator/testcases/content.py
@@ -263,8 +263,8 @@ def test_signed_xpi(err, xpi_package):
     """Checks if XPI is signed."""
     search = set([
         'META-INF/manifest.mf',
-        'META-INF/zigbert.rsa',
-        'META-INF/zigbert.sf'])
+        'META-INF/mozilla.rsa',
+        'META-INF/mozilla.sf'])
 
     if search.issubset(set(xpi_package)):
         err.warning(


### PR DESCRIPTION
Fixes [bug 1070188](https://bugzilla.mozilla.org/show_bug.cgi?id=1070188) (again)