### PR TITLE
Bug 1163799: Fix issues with the celery queues when validator tasks fail

### DIFF
--- a/validator/loader.py
+++ b/validator/loader.py
@@ -1,3 +1,12 @@
+"""
+Presumably, the purpose of this module is to load things in an order such
+that they do not cause import loops. Given how easy it is, at the moment,
+to cause import loops by making trivial changes, this presumption is likely
+valid.
+
+It probably also has the effect of making sure each of these modules registers
+its testcases in the appropriate places before we begin running tests.
+"""
 import validator.testcases.chromemanifest
 # Import this before content to avoid import loops.
 import validator.testcases.javascript.traverser

--- a/validator/main.py
+++ b/validator/main.py
@@ -1,25 +1,22 @@
 import argparse
 import json
-import os
 import sys
-import zipfile
-from StringIO import StringIO
 
+from validator import constants
 from validator.validate import validate
-from constants import *
 
 
 def main():
     "Main function. Handles delegation to other functions."
 
-    expectations = {"any": PACKAGE_ANY,
-                    "extension": PACKAGE_EXTENSION,
-                    "theme": PACKAGE_THEME,
-                    "dictionary": PACKAGE_DICTIONARY,
-                    "languagepack": PACKAGE_LANGPACK,
-                    "search": PACKAGE_SEARCHPROV,
-                    "multi": PACKAGE_MULTI,
-                    "webapp": PACKAGE_WEBAPP}
+    type_choices = {"any": constants.PACKAGE_ANY,
+                    "extension": constants.PACKAGE_EXTENSION,
+                    "theme": constants.PACKAGE_THEME,
+                    "dictionary": constants.PACKAGE_DICTIONARY,
+                    "languagepack": constants.PACKAGE_LANGUAGEPACK,
+                    "search": constants.PACKAGE_SEARCH,
+                    "multi": constants.PACKAGE_MULTI,
+                    "webapp": constants.PACKAGE_WEBAPP}
 
     # Parse the arguments that
     parser = argparse.ArgumentParser(
@@ -30,7 +27,7 @@ def main():
     parser.add_argument("-t",
                         "--type",
                         default="any",
-                        choices=expectations.keys(),
+                        choices=type_choices.keys(),
                         help="Type of addon you assume you're testing",
                         required=False)
     parser.add_argument("-o",
@@ -98,7 +95,7 @@ def main():
 
     # We want to make sure that the output is expected. Parse out the expected
     # type for the add-on and pass it in for validation.
-    if args.type not in expectations:
+    if args.type not in type_choices:
         # Fail if the user provided invalid input.
         print "Given expectation (%s) not valid. See --help for details" % \
                 args.type
@@ -106,9 +103,9 @@ def main():
 
     overrides = {}
     if args.target_minversion:
-       overrides['targetapp_minVersion'] = json.loads(args.target_minversion)
+        overrides['targetapp_minVersion'] = json.loads(args.target_minversion)
     if args.target_maxversion:
-       overrides['targetapp_maxVersion'] = json.loads(args.target_maxversion)
+        overrides['targetapp_maxVersion'] = json.loads(args.target_maxversion)
 
     for_appversions = None
     if args.for_appversions:
@@ -120,14 +117,14 @@ def main():
         print "Invalid timeout. Integer expected."
         sys.exit(1)
 
-    expectation = expectations[args.type]
+    expectation = type_choices[args.type]
     error_bundle = validate(args.package,
                             format=None,
                             approved_applications=args.approved_applications,
                             determined=args.determined,
                             listed=not args.selfhosted,
                             overrides=overrides,
-                            spidermonkey=SPIDERMONKEY_INSTALLATION,
+                            spidermonkey=constants.SPIDERMONKEY_INSTALLATION,
                             for_appversions=for_appversions,
                             expectation=expectation,
                             timeout=timeout)

--- a/validator/submain.py
+++ b/validator/submain.py
@@ -39,15 +39,12 @@ class ValidationTimeout(Exception):
 
 
 def prepare_package(err, path, expectation=0, for_appversions=None,
-                    timeout=None):
+                    timeout=-1):
     """Prepares a file-based package for validation.
 
     timeout is the number of seconds before validation is aborted.
     If timeout is -1 then no timeout checking code will run.
     """
-    if not timeout:
-        timeout = 60  # seconds
-
     # Test that the package actually exists. I consider this Tier 0
     # since we may not even be dealing with a real file.
     if err and not os.path.isfile(path):
@@ -80,10 +77,6 @@ def prepare_package(err, path, expectation=0, for_appversions=None,
     validation_state = {'complete': False}
 
     def timeout_handler(signum, frame):
-        if validation_state['complete']:
-            # There is no need for a timeout. This might be the result of
-            # sequential validators, like in the test suite.
-            return
         ex = ValidationTimeout(timeout)
         log.error("%s; Package: %s" % (str(ex), path))
         raise ex
@@ -91,8 +84,17 @@ def prepare_package(err, path, expectation=0, for_appversions=None,
     if timeout != -1:
         signal.signal(signal.SIGALRM, timeout_handler)
         signal.setitimer(signal.ITIMER_REAL, timeout)
-    output = test_package(err, package, path, expectation,
-                          for_appversions)
+
+    try:
+        output = test_package(err, package, path, expectation,
+                              for_appversions)
+    finally:
+        # Remove timers and signal handlers regardless of whether
+        # we've completed successfully or the timer has fired.
+        if timeout != -1:
+            signal.setitimer(signal.ITIMER_REAL, 0)
+            signal.signal(signal.SIGALRM, signal.SIG_DFL)
+
     validation_state['complete'] = True
     package.close()
 

--- a/validator/submain.py
+++ b/validator/submain.py
@@ -14,7 +14,8 @@ from validator.rdf import RDFException, RDFParser
 from validator.xpi import XPIManager
 from validator import decorator
 
-from constants import *
+from constants import (PACKAGE_ANY, PACKAGE_EXTENSION, PACKAGE_SEARCHPROV,
+                       PACKAGE_THEME, PACKAGE_WEBAPP)
 
 types = {0: "Unknown",
          1: "Extension/Multi-Extension",
@@ -158,7 +159,7 @@ def test_package(err, file_, name, expectation=PACKAGE_ANY,
     if package.extension in assumed_extensions:
         assumed_type = assumed_extensions[package.extension]
         # Is the user expecting a different package type?
-        if not expectation in (PACKAGE_ANY, assumed_type):
+        if expectation not in (PACKAGE_ANY, assumed_type):
             err.error(("main",
                        "test_package",
                        "unexpected_type"),
@@ -226,14 +227,14 @@ def _load_install_rdf(err, package, expectation):
 
     # Compare the results of the low-level type detection to
     # that of the expectation and the assumption.
-    if not expectation in (PACKAGE_ANY, results):
+    if expectation not in (PACKAGE_ANY, results):
         err.warning(
             err_id=("main", "test_package", "extension_type_mismatch"),
             warning="Extension Type Mismatch",
             description=("We detected that the add-on's type does not match "
                          "the expected type.",
                          'Type "%s" expected, found "%s"' %
-                             (types[expectation], types[results])))
+                         (types[expectation], types[results])))
 
 
 def _load_package_json(err, package, expectation):

--- a/validator/validate.py
+++ b/validator/validate.py
@@ -18,7 +18,7 @@ def validate(path, format="json",
              expectation=PACKAGE_ANY,
              for_appversions=None,
              overrides=None,
-             timeout=None,
+             timeout=-1,
              compat_test=False,
              **kw):
     """
@@ -51,7 +51,8 @@ def validate(path, format="json",
         A dict of app GUIDs referencing lists of versions. Determines which
         version-dependant tests should be run.
     `timeout`:
-        Number of seconds before aborting addon validation.
+        Number of seconds before aborting addon validation, or -1 for to
+        run with no timeout.
     `compat_tests`:
         A flag to signal the validator to skip tests which should not be run
         during compatibility bumps. Defaults to `False`.

--- a/validator/validate.py
+++ b/validator/validate.py
@@ -4,8 +4,10 @@ import types
 
 from . import constants
 from .constants import PACKAGE_ANY
-from errorbundler import ErrorBundle
-import loader
+from .errorbundler import ErrorBundle
+# This is necessary. Do not remove it unless you know exactly what
+# you are doing.
+import loader  # noqa
 import submain
 
 
@@ -44,14 +46,14 @@ def validate(path, format="json",
         Whether the app is headed for the app marketplace or AMO. Defaults to
         `True`.
     `expectation`:
-        The type of package that should be expected. Must be a symbolic constant
-        from validator.constants (i.e.: validator.constants.PACKAGE_*). Defaults
-        to PACKAGE_ANY.
+        The type of package that should be expected. Must be a symbolic
+        constant from validator.constants (i.e.:
+        validator.constants.PACKAGE_*). Defaults to PACKAGE_ANY.
     `for_appversions`:
         A dict of app GUIDs referencing lists of versions. Determines which
         version-dependant tests should be run.
     `timeout`:
-        Number of seconds before aborting addon validation, or -1 for to
+        Number of seconds before aborting addon validation, or -1 to
         run with no timeout.
     `compat_tests`:
         A flag to signal the validator to skip tests which should not be run


### PR DESCRIPTION
This is part of a two-part fix for issues in the task queues when validator tasks fail.

The current code never cleans up its timers or signal handlers before returning, which means that the timer will fire after the timeout interval even after the `validate` function has returned. When the task completes successfully, this is relatively harmless, since it sets a flag that essentially disarms the signal handler callback. When there's an exception, the flag is not set, which means the timer fires at an arbitrary point during the execution of the task process, and raises a `ValidationTimeout` exception, likely breaking something important.

This code cleans up the timeout and signal handler after they're no longer needed, and installs a timeout by default only when launched from as a system command.

A companion pull request for Olympia will move the handling of timeouts to Celery, where it belongs.