### PR TITLE
Bug 1183399: Add suggestions for addressing each validator message with a signing severity.

### DIFF
--- a/tests/test_js_wrappedjsobject.py
+++ b/tests/test_js_wrappedjsobject.py
@@ -136,4 +136,4 @@ class TestWrappedJSObject(TestCase):
         """)
         self.assert_failed(with_warnings=[
             {"id": ("testcases_js_xpcom", "xpcnativewrapper", "shallow"),
-             "signing_severity": "medium"}])
+             "signing_severity": "high"}])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,11 @@
+import mock
+import sys
+
 from validator.main import main
 
-def test_main():
+
+@mock.patch.object(sys, 'stderr')
+def test_main(stderr):
     """Test that `main()` initializes without errors."""
     try:
         main()

--- a/tests/test_packagelayout.py
+++ b/tests/test_packagelayout.py
@@ -1,8 +1,11 @@
 from itertools import repeat
 
-import validator.testcases.packagelayout as packagelayout
+from nose.tools import eq_
+
+from .helper import _do_test, MockXPI
+
 from validator.errorbundler import ErrorBundle
-from helper import _do_test, MockXPI
+from validator.testcases import packagelayout
 
 
 def test_blacklisted_files():
@@ -36,8 +39,9 @@ def test_java_jar_detection():
     err = ErrorBundle(None, True)
     packagelayout.test_blacklisted_files(err, mock_xpi)
 
-    assert not err.failed()
-    assert err.notices
+    assert err.warnings
+    eq_(err.warnings[0]['id'],
+        ("testcases_packagelayout", "test_blacklisted_files", "java_jar"))
 
 
 def test_blacklisted_magic_numbers():

--- a/validator/errorbundler.py
+++ b/validator/errorbundler.py
@@ -94,6 +94,7 @@ class ErrorBundle(object):
             }
             for field in ("tier", "for_appversions", "compatibility_type", ):
                 message[field] = kwargs.get(field)
+
             if "signing_severity" in kwargs:
                 severity = kwargs["signing_severity"]
 
@@ -102,6 +103,8 @@ class ErrorBundle(object):
                 if not kwargs.get("from_merge"):
                     self.signing_summary[severity] += 1
                 message["signing_severity"] = severity
+            if "signing_help" in kwargs:
+                message["signing_help"] = kwargs["signing_help"]
 
             self._save_message(getattr(self, type_), type_, message,
                                from_merge=kwargs.get("from_merge"),
@@ -306,6 +309,7 @@ class ErrorBundle(object):
                     "editors_only",
                     "for_appversions",
                     "line",
+                    "signing_help",
                     "signing_severity",
                     "tier")
 
@@ -455,6 +459,12 @@ class ErrorBundle(object):
                 verbose_output.append(
                     ("\tAutomated signing severity: %s" %
                      message["signing_severity"]))
+
+            if message.get("signing_help"):
+                verbose_output.append(
+                    "\tSuggestions for passing automated signing:")
+                verbose_output.append(
+                    self._flatten_list(message["signing_help"]))
 
             # Show the user what tier we're on
             verbose_output.append("\tTier:\t%d" % message["tier"])

--- a/validator/testcases/chromemanifest.py
+++ b/validator/testcases/chromemanifest.py
@@ -16,9 +16,18 @@ DANGEROUS_CATEGORY_WARNING = {
     "err_id": ("testcases_chromemanifest", "test_resourcemodules",
                "resource_modules"),
     "warning": "Potentially dangerous category entry",
-    "description": "Add-ons definining global properties via category "
+    "description": "Add-ons defining global properties via category "
                    "entries require careful review by an administrative "
                    "reviewer.",
+    "signing_help": (
+        "Given the potential security risks of exposing APIs to unprivileged "
+        "code, extensions which use these APIs must undergo manual code "
+        "review for at least one submission. If you are not using these APIs "
+        "to interact with content code, please consider alternatives, such as "
+        "JavaScript modules (http://mzl.la/1HMH2m9), CommonJS modules "
+        "(http://mzl.la/1JBMjuU, http://mzl.la/1OBaE8u), the observer "
+        "service (http://mzl.la/1MLqWdJ), or window listeners which install "
+        "global properties on privileged windows."),
     "signing_severity": "medium",
     "editors_only": True}
 
@@ -53,7 +62,7 @@ def test_resourcemodules(err):
 
     for triple in chrome.triples:
         if (triple["subject"] == "resource" and
-            triple["predicate"].startswith("modules")):
+                triple["predicate"].startswith("modules")):
             err.error(
                 err_id=("testcases_chromemanifest", "test_resourcemodules",
                         "resource_modules"),
@@ -114,4 +123,3 @@ def test_content_instructions(err):
                 filename=triple["filename"],
                 line=triple["line"],
                 context=triple["context"])
-

--- a/validator/testcases/javascript/actions.py
+++ b/validator/testcases/javascript/actions.py
@@ -504,6 +504,12 @@ def _call_settimeout(a, t, e):
                 "In order to prevent vulnerabilities, the `setTimeout` "
                 "and `setInterval` functions should be called only with "
                 "function expressions as their first argument.",
+            "signing_help": (
+                "Please do not ever call `setTimeout` or `setInterval` with "
+                "string arguments. If you are passing a function which is "
+                "not being correctly detected as such, please consider "
+                "passing a closure or arrow function, which in turn calls "
+                "the original function."),
             "signing_severity": "high"}
 
 

--- a/validator/testcases/javascript/call_definitions.py
+++ b/validator/testcases/javascript/call_definitions.py
@@ -287,7 +287,13 @@ def js_wrap(wrapper, arguments, traverser):
             description="Shallow XPCOM wrappers are seldom necessary and "
                         "should not be used. Please use deep wrappers "
                         "instead.",
-            signing_severity="medium")
+            signing_help="Extensions making use of shallow wrappers will not "
+                         "be accepted for automated signing. Please remove "
+                         "the second and subsequent arguments of any calls "
+                         "to `XPCNativeWrapper`, as well as any code which "
+                         "applies `XPCNativeWrapper` to properties obtained "
+                         "from these shallowly wrapped objects.",
+            signing_severity="high")
         # Do not mark shallow wrappers as not unwrapped.
         return obj
 

--- a/validator/testcases/javascript/instanceactions.py
+++ b/validator/testcases/javascript/instanceactions.py
@@ -108,6 +108,11 @@ def _create_script_tag(traverser):
         description="Dynamic creation of script nodes can be unsafe if "
                     "contents are not static or are otherwise unsafe, "
                     "or if `src` is remote.",
+        signing_help="Please avoid using <script> tags to load scripts. "
+                     "For potential alternatives, please see "
+                     "https://developer.mozilla.org/en-US/Add-ons/"
+                     "Overlay_Extensions/XUL_School/"
+                     "Appendix_D:_Loading_Scripts",
         signing_severity="medium")
 
 
@@ -146,6 +151,11 @@ def setAttribute(args, traverser, node, wrapper):
             description="To prevent vulnerabilities, event handlers (like "
                         "'onclick' and 'onhover') should always be defined "
                         "using addEventListener.",
+            signing_help="Please use `addEventListener` any place you might "
+                         "otherwise create event listener attributes. Event "
+                         "listener attributes will not be accepted in add-ons "
+                         "submitted for automated signing in any instance "
+                         "where they may be reasonably avoided.",
             signing_severity="medium")
 
 

--- a/validator/testcases/javascript/instanceproperties.py
+++ b/validator/testcases/javascript/instanceproperties.py
@@ -29,6 +29,19 @@ def _set_HTML_property(function, new_value, traverser):
         if isinstance(literal_value, types.StringTypes):
             # Static string assignments
 
+            HELP = ("Please avoid including JavaScript fragments in "
+                    "HTML stored in JavaScript strings. Event listeners "
+                    "should be added via `addEventListener` after the HTML "
+                    "has been injected.",
+                    "Injecting <script> nodes should be avoided when at all "
+                    "possible. If you cannot avoid loading a script directly "
+                    "into a content document, please consider doing so via "
+                    "the subscript loader (http://mzl.la/1VGxOPC) instead. "
+                    "If the subscript loader is not available, then the "
+                    "script nodes should be created using `createElement`, "
+                    "and should use a `src` attribute pointing to a "
+                    "`resource:` URL within your extension.")
+
             # Test for on* attributes and script tags.
             if EVENT_ASSIGNMENT.search(literal_value.lower()):
                 traverser.warning(
@@ -41,6 +54,7 @@ def _set_HTML_property(function, new_value, traverser):
                                  % function,
                                  "Event handler code: %s"
                                  % literal_value.encode("ascii", "replace")),
+                    signing_help=HELP,
                     signing_severity="medium")
             elif ("<script" in literal_value or
                   JS_URL.search(literal_value)):
@@ -53,6 +67,7 @@ def _set_HTML_property(function, new_value, traverser):
                                 "pages via script tags or JavaScript URLs. "
                                 "Instead, use event listeners and external "
                                 "JavaScript." % function,
+                    signing_help=HELP,
                     signing_severity="medium")
             else:
                 # Everything checks out, but we still want to pass it through
@@ -96,6 +111,10 @@ def set_on_event(new_value, traverser):
                         "assigned by setting an on* property to a "
                         "string of JS code. Rather, consider using "
                         "addEventListener.",
+            signing_help="Please add event listeners using the "
+                         "`addEventListener` API. If the property you are "
+                         "assigning to is not an event listener, please "
+                         "consider renaming it, if at all possible.",
             signing_severity="medium")
     elif (not is_literal and isinstance(new_value.value, jstypes.JSObject) and
           "handleEvent" in new_value.value.data):
@@ -128,6 +147,14 @@ def set__exposedProps__(new_value, traverser):
             "scopes is dangerous, and has been deprecated. If objects "
             "must be exposed to unprivileged scopes, `cloneInto` or "
             "`exportFunction` should be used instead."),
+        signing_help="If you are using this API to expose APIs to content, "
+                     "please use `Components.utils.cloneInto`, or "
+                     "`Components.utils.exportFunction` "
+                     "(http://mzl.la/1fvvgm9). If you are using it "
+                     "for other purposes, please consider using a built-in "
+                     "message passing interface instead. Extensions which "
+                     "expose APIs to content will be required to go through "
+                     "manual code review for at least one submission.",
         signing_severity="high")
 
 
@@ -152,6 +179,8 @@ def set_contentScript(value, traverser):
                         "is dangerous and error-prone. Please use a separate "
                         "JavaScript file, along with the "
                         "`contentScriptFile` property instead.",
+            signing_help="Please do not use the `contentScript` property "
+                         "in any add-ons submitted for automated signing.",
             signing_severity="high")
 
 

--- a/validator/testcases/javascript/jstypes.py
+++ b/validator/testcases/javascript/jstypes.py
@@ -71,6 +71,15 @@ class JSObject(object):
                                 "result in serious security vulnerabilities. "
                                 "Please reconsider your use of unwrapped "
                                 "JS objects.",
+                    signing_help="Please avoid assigning to properties of "
+                                 "unwrapped objects from unprivileged scopes, "
+                                 "unless you are using an export API "
+                                 "(http://mzl.la/1fvvgm9) to expose API "
+                                 "functions to content scopes. "
+                                 "In this case, however, please note that "
+                                 "your add-on will be required to undergo "
+                                 "manual code review for at least one "
+                                 "submission.",
                     signing_severity="high")
 
         self.data[name] = value

--- a/validator/testcases/markup/markuptester.py
+++ b/validator/testcases/markup/markuptester.py
@@ -9,7 +9,6 @@ import validator.unicodehelper as unicodehelper
 from validator.testcases.markup import csstester
 from validator.contextgenerator import ContextGenerator
 from validator.constants import *
-from validator.decorator import version_range
 
 DEBUG = False
 
@@ -77,7 +76,6 @@ class MarkupParser(HTMLParser):
         lines = data.split("\n")
 
         buffering = False
-        pline = 0
         for line in lines:
             self.line += 1
 
@@ -312,6 +310,14 @@ class MarkupParser(HTMLParser):
                         warning="Scripts must not be remote",
                         description="<script> tags must not be referenced to "
                                     "script files that are hosted remotely.",
+                        signing_help="Please do not attempt to load remote "
+                                     "scripts into any privileged contexts. "
+                                     "If you cannot avoid using remote "
+                                     "scripts, please consider loading a "
+                                     "remote document into an iframe, and "
+                                     "allow that document to load the "
+                                     "remote scripts that you need.",
+                        signing_severity="high",
                         filename=self.filename,
                         line=self.line,
                         context=self.context)

--- a/validator/testcases/packagelayout.py
+++ b/validator/testcases/packagelayout.py
@@ -51,6 +51,17 @@ def test_blacklisted_files(err, xpi_package=None):
 
     flagged_files = []
 
+    HELP = ("Please try to avoid interacting with or bundling "
+            "native binaries whenever possible. If you are "
+            "bundling binaries for performance reasons, please "
+            "consider alternatives such as Emscripten "
+            "(http://mzl.la/1KrSUh2), JavaScript typed arrays "
+            "(http://mzl.la/1Iw02sr), and Worker threads "
+            "(http://mzl.la/1OGfAcc).",
+            "Any code which bundles native binaries must "
+            "submit full source code, and undergo manual code review "
+            "for at least one submission.")
+
     for name in xpi_package:
         file_ = xpi_package.info(name)
         # Simple test to ensure that the extension isn't blacklisted
@@ -69,16 +80,14 @@ def test_blacklisted_files(err, xpi_package=None):
             # Note that there is binary content in the metadata
             err.metadata["contains_binary_content"] = True
             err.warning(
-                err_id=("testcases_packagelayout",
-                        "test_blacklisted_files",
+                err_id=("testcases_packagelayout", "test_blacklisted_files",
                         "disallowed_file_type"),
                 warning="Flagged file type found",
-                description=("A file was found to contain flagged content "
-                             "(i.e.: executable data, potentially "
-                             "unauthorized scripts, etc.).",
-                             u"The file \"%s\" contains flagged content" %
-                                 name),
+                description="A file was found to contain flagged content "
+                            "(i.e.: executable data, potentially "
+                            "unauthorized scripts, etc.).",
                 editors_only=True,
+                signing_help=HELP,
                 signing_severity="high",
                 filename=name)
 
@@ -86,13 +95,14 @@ def test_blacklisted_files(err, xpi_package=None):
         # Detect Java JAR files:
         if (sum(1 for f in flagged_files if f.endswith(".class")) >
                 JAVA_JAR_THRESHOLD):
-            err.notice(
-                err_id=("testcases_packagelayout",
-                        "test_blacklisted_files",
+            err.warning(
+                err_id=("testcases_packagelayout", "test_blacklisted_files",
                         "java_jar"),
-                notice="Java JAR file detected.",
+                warning="Java JAR file detected.",
                 description="A Java JAR file was detected in the add-on.",
-                filename=xpi_package.filename)
+                filename=xpi_package.filename,
+                signing_help=HELP,
+                signing_severity="high")
         else:
             err.warning(
                 err_id=("testcases_packagelayout",
@@ -101,15 +111,16 @@ def test_blacklisted_files(err, xpi_package=None):
                 warning="Flagged file extensions found.",
                 description=("Files whose names end with flagged extensions "
                              "have been found in the add-on.",
-                             "The extension of these files are flagged because "
-                             "they usually identify binary components. Please "
-                             "see "
+                             "The extension of these files are flagged "
+                             "because they usually identify binary "
+                             "components. Please see "
                              "http://addons.mozilla.org/developers/docs/"
-                                 "policies/reviews#section-binary"
+                             "policies/reviews#section-binary"
                              " for more information on the binary content "
                              "review process.",
                              "\n".join(flagged_files)),
                 editors_only=True,
+                signing_help=HELP,
                 signing_severity="medium",
                 filename=name)
 
@@ -134,7 +145,7 @@ def test_godlikea(err, xpi_package):
         versions={FIREFOX_GUID: version_range("firefox", FF4_MIN),
                   TB_GUID: version_range("thunderbird", "3.3a4pre"),
                   FENNEC_GUID: version_range("fennec", "4.0"),
-                  ANDROID_GUID: version_range("android", "11.0a1"),})
+                  ANDROID_GUID: version_range("android", "11.0a1")})
 def test_compatibility_binary(err, xpi_package):
     """
     Flags only binary content as being incompatible with future app releases.


### PR DESCRIPTION
These should be all of the validator-side changes. Olympia changes will be required to display the messages, but they won't cause any trouble on the Olympia side in the mean time.