### PR TITLE
Handle certain XPI corruption errors more gracefully.

### DIFF
--- a/validator/testcases/content.py
+++ b/validator/testcases/content.py
@@ -106,8 +106,16 @@ def test_packed_packages(err, xpi_package=None):
         file_data = u''
         try:
             file_data = xpi_package.read(name)
-        except KeyError:  # pragma: no cover
+        except KeyError:
             pass
+        except BadZipfile:
+            err.error(('testcases_content',
+                       'test_packed_packages',
+                       'jar_subpackage_corrupt'),
+                      'Package corrupt',
+                      'The package appears to be corrupt.',
+                      file=xpi_package.filename)
+            break
 
         if not err.for_appversions:
             hash = hashlib.sha256(file_data).hexdigest()


### PR DESCRIPTION
I kept coming across stack traces for this when testing against existing extensions. The validator currently throws errors when it comes across XPIs that use `\` rather than `/` in paths.