### PR TITLE
Revert "Whitelist empty file (bug 1224812)"

### DIFF
--- a/validator/testcases/static_hashes.txt
+++ b/validator/testcases/static_hashes.txt
@@ -1,5 +1,4 @@
 2c424ecc3b35a0b11f3492452645a3e0c949f313cf3c36e2307ebcaef2f135bc  This file is a false script to facilitate testing of library blacklisting.
-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  This is an empty file.
 bf09094376256ea8b26982862dff3eae5c39a5f59b25f18f487b56d270a92820  bootstrap.js
 cf069116c5a10c9086aa253298e246fa91e71bcfcb44c18fc936c37cd6da93ac  kango/backgroundscript_engine.js
 763b2d49a6ca8beb72fd0e085972cb5ba615b74dbc1c36bdb11ebb0642f9e14a  kango/base.js


### PR DESCRIPTION
This needs to be backed out as the validator not only iterates through files but also folders to find libraries (ugh).
Fixing that issue alone is not sufficient, because we probably do want the validator to recognize empty files, but they should not be part of the (html) report. They should just be greyed out in the source viewer.

r?