### PR TITLE
Use '*' as the default strict_max_version for WebExtension

### DIFF
--- a/tests/test_json_parser.py
+++ b/tests/test_json_parser.py
@@ -43,7 +43,7 @@ def test_get_applications():
     parser = ManifestJsonParser(None, manifest_json)
     assert parser.get_applications() == [{u'guid': FIREFOX_GUID,
                                           u'min_version': u'42.0',
-                                          u'max_version': u'42.*'}]
+                                          u'max_version': u'*'}]
 
 
 def test_get_applications_with_versions():

--- a/tests/test_targetapplication.py
+++ b/tests/test_targetapplication.py
@@ -1,14 +1,11 @@
 import json
 from mock import patch
 import validator.testcases.targetapplication as targetapp
+from validator.constants import APPROVED_APPLICATIONS
 from validator.errorbundler import ErrorBundle
 from validator.json_parser import ManifestJsonParser
 from validator.rdf import RDFParser
 from helper import _do_test
-
-
-targetapp.APPROVED_APPLICATIONS = \
-        json.load(open('validator/app_versions.json'))
 
 
 def _do_test_raw(rdf, listed=True, overrides=None):
@@ -81,8 +78,10 @@ def test_valid_targetapps_webextension_missing_min_max():
     assert len(supports) == 1
 
     supported_versions = results.supported_versions
-    assert (supported_versions['{ec8030f7-c20a-464f-9b0e-13a3a9e97384}'] ==
-            ['42.0', '42.*'])
+    supported_firefox_versions = supported_versions[
+        '{ec8030f7-c20a-464f-9b0e-13a3a9e97384}']
+    assert '42.0' in supported_firefox_versions  # Automatic min version.
+    assert '*' in supported_firefox_versions  # Automatic max version.
 
 
 def test_bad_min_max():

--- a/validator/constants.py
+++ b/validator/constants.py
@@ -43,6 +43,10 @@ APPLICATIONS = {
 with open(os.path.join(os.path.dirname(__file__), 'app_versions.json')) as avs:
     APPROVED_APPLICATIONS = json.load(avs)
 
+# Add the '*' fake max version. Used specifically for WebExtensions, see
+# https://github.com/mozilla/amo-validator/issues/390.
+APPROVED_APPLICATIONS['1']['versions'].append('*')
+
 BUGZILLA_BUG = 'https://bugzil.la/%d'
 MDN_DOC = 'https://developer.mozilla.org/docs/%s'
 

--- a/validator/json_parser.py
+++ b/validator/json_parser.py
@@ -17,7 +17,7 @@ class ManifestJsonParser(object):
             return []
         app = self.data['applications']['gecko']
         min_version = app.get('strict_min_version', u'42.0')
-        max_version = app.get('strict_max_version', u'42.*')
+        max_version = app.get('strict_max_version', u'*')
         return [{u'guid': FIREFOX_GUID,
                  u'min_version': min_version,
                  u'max_version': max_version}]

--- a/validator/validate.py
+++ b/validator/validate.py
@@ -66,6 +66,9 @@ def validate(path, format='json',
         # path (string).
         with open(approved_applications) as approved_apps:
             apps = json.load(approved_apps)
+        # Add the '*' fake max version. Used specifically for WebExtensions,
+        # see https://github.com/mozilla/amo-validator/issues/390.
+        apps['1']['versions'].append('*')
     elif isinstance(approved_applications, dict):
         # If the lists of approved applications are already in a dict, just use
         # that instead of trying to pull from a file.


### PR DESCRIPTION
Fixes #390