### PR TITLE
Update links to point to github

### DIFF
--- a/validator/errorbundler.py
+++ b/validator/errorbundler.py
@@ -152,7 +152,7 @@ class ErrorBundle(object):
                     'to an unexpected error.',
                     'The error has been logged, but please consider '
                     'filing an issue report here: '
-                    'http://mzl.la/1DG0sFd'),
+                    'https://bit.ly/1paBbSy'),
                    tier=1, **kw)
 
         # Move the error message to the beginning of the list.

--- a/validator/submain.py
+++ b/validator/submain.py
@@ -77,7 +77,8 @@ def prepare_package(err, path, expectation=0, for_appversions=None,
                          'time. This is most likely due to the size or '
                          'complexity of your add-on.',
                          'This timeout has been logged, but please consider '
-                         'filing an issue report here: http://mzl.la/1DG0sFd'),
+                         'filing an issue report here: '
+                         'https://bit.ly/1paBbSy'),
             exc_info=sys.exc_info())
 
     except Exception:


### PR DESCRIPTION
Note: This makes us lose the template unless we use https://github.com/blog/2111-issue-and-pull-request-templates but that would make it the default for all newly filed issues.

r?