### PR TITLE
Support correctly decoding BOM encoding for manifest.json.

### DIFF
--- a/tests/test_manifestjson.py
+++ b/tests/test_manifestjson.py
@@ -58,6 +58,23 @@ def test_version_must_be_valid():
     assert err.failed(), 'expected invalid version to fail'
 
 
+def test_supports_bom_encoding():
+    err = ErrorBundle()
+    manifest_json = """\xef\xbb\xbf{
+        "name": "My Awesome Addon",
+        "version": "1.25",
+
+        "applications": {
+            "gecko": {
+                "id": "my@awesome.addon"
+            }
+        }
+    }"""
+    err.save_resource('has_manifest_json', True)
+    err.save_resource('manifest_json', ManifestJsonParser(err, manifest_json))
+    assert not err.failed()
+
+
 def setup_err():
     err = ErrorBundle()
     manifest_json = """{

--- a/validator/json_parser.py
+++ b/validator/json_parser.py
@@ -1,5 +1,6 @@
 import json
 
+from validator import unicodehelper
 from validator.constants import FIREFOX_GUID
 
 
@@ -8,7 +9,7 @@ class ManifestJsonParser(object):
 
     def __init__(self, err, data, namespace=None):
         self.err = err
-        self.data = json.loads(data)
+        self.data = json.loads(unicodehelper.decode(data))
 
     def get_applications(self):
         """Return the list of supported applications."""


### PR DESCRIPTION
Fixes mozilla/addons-server#2038
