### PR TITLE
Use correct filename(s) for binary warning

### DIFF
--- a/tests/test_packagelayout.py
+++ b/tests/test_packagelayout.py
@@ -17,6 +17,8 @@ def test_blacklisted_files():
                    packagelayout.test_blacklisted_files,
                    True)
     assert err.metadata['contains_binary_extension']
+    assert any(warning['id'][1] == 'test_blacklisted_files'
+        and warning['file'] == 'omgitsadll.dll' for warning in err.warnings)
     assert not any(count for (key, count) in err.compat_summary.items())
 
     # Run the compatibility test on this, but it shouldn't fail or produce

--- a/validator/testcases/packagelayout.py
+++ b/validator/testcases/packagelayout.py
@@ -122,7 +122,7 @@ def test_blacklisted_files(err, xpi_package=None):
                 editors_only=True,
                 signing_help=HELP,
                 signing_severity='medium',
-                filename=name)
+                filename=', '.join(flagged_files))
 
 
 @decorator.register_test(tier=1)


### PR DESCRIPTION
Fixes #411