### PR TITLE
Revert Add public warning about using ctypes

### DIFF
--- a/tests/test_js_signing.py
+++ b/tests/test_js_signing.py
@@ -342,6 +342,7 @@ class TestSearchService(TestCase, RegexTestCase):
         """)
         self.assert_failed(with_warnings=[
             {'id': ('js', 'traverser', 'dangerous_global'),
+             'editors_only': True,
              'signing_severity': 'high'}])
 
     def test_nsIProcess(self):

--- a/validator/testcases/javascript/predefinedentities.py
+++ b/validator/testcases/javascript/predefinedentities.py
@@ -707,12 +707,12 @@ GLOBAL_ENTITIES = {
 
     u'ctypes': {'dangerous': {
         'description': (
-            'Starting with Firefox 53, to be released on April 18, Firefox '
-            'will prevent the loading of third-party binaries. If you are '
-            'currently using JS-ctypes, you should begin immediately '
-            'transitioning to the Native Messaging API using WebExtensions '
-            '(see https://mzl.la/2j4bEwp for documentation and examples). '
-            'See also https://mzl.la/2joSS11 for the announcement blogpost.'),
+            'Insufficiently meticulous use of ctypes can lead to serious, '
+            'and often exploitable, errors. The use of bundled binary code, '
+            'or access to system libraries, may allow for add-ons to '
+            'perform unsafe operations. All ctypes use must be carefully '
+            'reviewed by a qualified reviewer.'),
+        'editors_only': True,
         'signing_help': ('Please try to avoid interacting with or bundling '
                          'native binaries whenever possible. If you are '
                          'bundling binaries for performance reasons, please '


### PR DESCRIPTION
Reverting because by the time you'd see the public warning, you aren't part of the target audience for that warning anymore because after the validation ran, the add-on has already been created and subsequent submissions are just updates that aren't affected.