### PR TITLE
Fix Fx53 compat tests regex's

### DIFF
--- a/validator/testcases/regex.py
+++ b/validator/testcases/regex.py
@@ -537,7 +537,7 @@ class Gecko53RegexTests(CompatRegexTestHelper):
     def tests(self):
         yield self.get_test_bug(
             1321556,
-            r'\burlbarBindings.xml\#splitmenu\b',
+            r'\burlbarBindings\.xml#splitmenu\b',
             'The splitmenu element has been removed.',
             'The splitmenu element has been removed.',
             log_function=self.err.warning,
@@ -545,7 +545,7 @@ class Gecko53RegexTests(CompatRegexTestHelper):
 
         yield self.get_test_bug(
             1331296,
-            r'\b[^-]*-moz-calc\b',
+            r'-moz-calc\b',
             'The -moz-calc function has been removed.',
             'You can use the equivalent calc instead',
             log_function=self.err.warning,


### PR DESCRIPTION
@EnTeQuAk I tried to run the Fx53 compat tests today and they keep timing out. After some digging, I am fairly confident that either or both of these regex's are utterly slow and cause the validation to hit the time limit for some add-ons.