### PR TITLE
Remove support for webextensions in amo-validator

### DIFF
--- a/functional_tests/test_validator.py
+++ b/functional_tests/test_validator.py
@@ -203,7 +203,9 @@ class GeneralTests(ValidatorTest):
     def test_webextension_seen_as_extension(self):
         validation = self.validate('beastify.xpi')
         assert validation['detected_type'] == 'extension'
-        assert validation['errors'] == 0
+        # WebExtensions are not supported by amo-validator anymore now that we
+        # have addons-linter.
+        assert validation['errors'] == 1
 
     def test_install_rdf_and_manifest_json(self):
         validation = self.validate('installrdf-and-manifestjson.xpi')

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -115,8 +115,8 @@ def test_validate_webextension():
     result = validate(path='tests/resources/validate/webextension.xpi')
     data = json.loads(result)
 
-    assert data['success'] is True
-    assert data['errors'] == 0
+    assert data['success'] is False
+    assert data['errors'] == 1
     assert data['notices'] == 0
     assert data['warnings'] == 0
     assert data['compatibility_summary']
@@ -124,14 +124,20 @@ def test_validate_webextension():
     assert data['compatibility_summary']['notices'] == 0
     assert data['compatibility_summary']['warnings'] == 0
     assert data['detected_type'] == 'extension'
-    assert data['messages'] == []
-    assert data['message_tree'] == {}
+    assert len(data['messages']) == 1
+    assert data['messages'][0]['id'] == [
+        u'submain', u'test_inner_package', u'webextension']
+    assert data['messages'][0]['message'] == (
+            'This tool only works with legacy add-ons. See '
+            'https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions '
+            'for more information about WebExtension APIs.')
+    assert data['messages'][0]['tier'] == 1
+    assert data['messages'][0]['type'] == 'error'
     assert data['signing_summary']['high'] == 0
     assert data['signing_summary']['medium'] == 0
     assert data['signing_summary']['low'] == 0
     assert data['signing_summary']['trivial'] == 0
     assert data['metadata']
-    assert data['metadata'].get('strict_compatibility') is None
     assert data['metadata']['is_extension'] is True
 
 

--- a/validator/submain.py
+++ b/validator/submain.py
@@ -166,7 +166,23 @@ def test_package(err, file_, name, expectation=PACKAGE_ANY,
             err.error(('main', 'test_package', 'unexpected_type'),
                       'Unexpected package type (found theme)')
 
-    test_inner_package(err, package, for_appversions)
+    if (err.get_resource('has_manifest_json') and
+            not err.get_resource('has_package_json') and
+            not err.get_resource('has_install_rdf')):
+        # It's a WebExtension. Those are not supported by amo-validator, we
+        # should be using the linter instead. Only reason we could be using
+        # amo validator with a WebExtension is if a developer tried to use
+        # the compatibilty checker with a WebExtension, so add a relevant error
+        # message.
+        format_args = {
+            'link': MDN_DOC % 'Mozilla/Add-ons/WebExtensions'
+        }
+        err.error(
+            ('submain', 'test_inner_package', 'webextension'),
+            'This tool only works with legacy add-ons. See {link} for more '
+            'information about WebExtension APIs.'.format(**format_args))
+    else:
+        test_inner_package(err, package, for_appversions)
 
 
 def _load_install_rdf(err, package, expectation):


### PR DESCRIPTION
Note: `test_validate_embedded_webextension_xpi` should ensure that we don't break support for embedded web extensions (I also tested this locally with a couple known embedded webextensions and a couple known webextensions) 

Supports https://github.com/mozilla/addons-server/issues/5950