### PR TITLE
Fix failing unittests on Python 2.7.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,4 +404,3 @@ change the locations that the various language files are stored in.
 
 Also note that this tool should only be run against the en-US versions of these
 applications.
-foo

--- a/README.md
+++ b/README.md
@@ -404,3 +404,4 @@ change the locations that the various language files are stored in.
 
 Also note that this tool should only be run against the en-US versions of these
 applications.
+foo


### PR DESCRIPTION
Fix failing unittests on python 2.7.14

The problem here is that `sax` closes any file-like object you're
passing it to and these days StringIO forces operations on closed files
to fail.

It's hard to find the actual commit that caused this change in Python
2.7.14 but explicitly reading the file and wrapping it in a new StringIO
object works.

This isn't ideal but RDF files should not be too large so that this
workaround does sound reasonable to me.