### PR TITLE
force amo-validator to be executed as python2

### DIFF
--- a/addon-validator
+++ b/addon-validator
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import validator.main
 
 


### PR DESCRIPTION
when addons-server is executing this in a python3 env it's defaulting to py3 which isn't working (because this package is py2 only).  So force the python to be v2.